### PR TITLE
add jinja filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+tchap/tchap/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 tchap/tchap/
+tchap/postgres/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,6 +3319,7 @@ dependencies = [
  "mas-router",
  "mas-storage",
  "mas-storage-pg",
+ "mas-tchap",
  "mas-templates",
  "mime",
  "minijinja",
@@ -3697,6 +3698,10 @@ dependencies = [
  "tracing-opentelemetry",
  "ulid",
 ]
+
+[[package]]
+name = "mas-tchap"
+version = "0.1.0"
 
 [[package]]
 name = "mas-templates"

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -103,6 +103,7 @@ mas-router.workspace = true
 mas-storage.workspace = true
 mas-storage-pg.workspace = true
 mas-templates.workspace = true
+mas-tchap = { path = "../tchap" }
 oauth2-types.workspace = true
 zxcvbn = "3.1.0"
 

--- a/crates/handlers/src/upstream_oauth2/template.rs
+++ b/crates/handlers/src/upstream_oauth2/template.rs
@@ -7,6 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use base64ct::{Base64, Base64Unpadded, Base64Url, Base64UrlUnpadded, Encoding};
+use mas_tchap;
 use minijinja::{
     Environment, Error, ErrorKind, Value,
     value::{Enumerator, Object},
@@ -187,6 +188,12 @@ pub fn environment() -> Environment<'static> {
     env.add_filter("tlvdecode", tlvdecode);
     env.add_filter("string", string);
     env.add_filter("from_json", from_json);
+    
+    // Add Tchap-specific filters, this could be a generic config submitted 
+    // to upstream allowing all users to add their own filters without upstream code modifications
+    // tester les fonctions async pour le reseau
+    env.add_filter("email_to_display_name", |s: &str| mas_tchap::email_to_display_name(s));
+    env.add_filter("email_to_mxid_localpart", |s: &str| mas_tchap::email_to_mxid_localpart(s));
 
     env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
 

--- a/crates/tchap/Cargo.toml
+++ b/crates/tchap/Cargo.toml
@@ -1,13 +1,7 @@
 [package]
 name = "mas-tchap"
 version = "0.1.0"
-edition = "2021"
 description = "Tchap-specific functionality for Matrix Authentication Service"
-license = "AGPL-3.0-only"
+license = "MIT"
 
 [dependencies]
-anyhow = "1.0.75"
-mas-data-model = { path = "../data-model" }
-mas-storage = { path = "../storage" }
-tracing = "0.1.37"
-uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }

--- a/crates/tchap/Cargo.toml
+++ b/crates/tchap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mas-tchap"
+version = "0.1.0"
+edition = "2021"
+description = "Tchap-specific functionality for Matrix Authentication Service"
+license = "AGPL-3.0-only"
+
+[dependencies]
+anyhow = "1.0.75"
+mas-data-model = { path = "../data-model" }
+mas-storage = { path = "../storage" }
+tracing = "0.1.37"
+uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -84,7 +84,6 @@ pub fn email_to_mxid_localpart(address: &str) -> String {
 /// This function:
 /// 1. Replaces dots with spaces in the username part
 /// 2. Determines the organization based on domain rules:
-///    - matrix.org emails are marked as "Tchap Admin"
 ///    - gouv.fr emails use the subdomain or "gouv" if none
 ///    - other emails use the second-level domain
 /// 3. Returns a display name in the format "Username [Organization]"
@@ -111,10 +110,7 @@ pub fn email_to_display_name(address: &str) -> String {
     // Figure out which org this email address belongs to
     let domain_parts: Vec<&str> = domain.split('.').collect();
     
-    let org = if domain_parts.len() >= 2 && domain_parts[domain_parts.len() - 2] == "matrix" && domain_parts[domain_parts.len() - 1] == "org" {
-        // If this is a ...matrix.org email, mark them as an Admin
-        "Tchap Admin"
-    } else if domain_parts.len() >= 2 && domain_parts[domain_parts.len() - 2] == "gouv" && domain_parts[domain_parts.len() - 1] == "fr" {
+    let org = if domain_parts.len() >= 2 && domain_parts[domain_parts.len() - 2] == "gouv" && domain_parts[domain_parts.len() - 1] == "fr" {
         // Is this is a ...gouv.fr address, set the org to whatever is before
         // gouv.fr. If there isn't anything (a @gouv.fr email) simply mark their
         // org as "gouv"
@@ -149,12 +145,6 @@ mod tests {
 
     #[test]
     fn test_email_to_display_name() {
-        // Test matrix.org email
-        assert_eq!(
-            email_to_display_name("john.doe@matrix.org"),
-            "John Doe [Tchap Admin]"
-        );
-
         // Test gouv.fr email with subdomain
         assert_eq!(
             email_to_display_name("jane.smith@example.gouv.fr"),
@@ -165,6 +155,18 @@ mod tests {
         assert_eq!(
             email_to_display_name("user@gouv.fr"),
             "User [Gouv]"
+        );
+
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("user@gendarmerie.gouv.fr"),
+            "User [Gendarmerie]"
+        );
+
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("user@gendarmerie.interieur.gouv.fr"),
+            "User [Interieur]"
         );
 
         // Test regular email

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -1,0 +1,206 @@
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+//! Tchap-specific functionality for Matrix Authentication Service
+
+
+/// Capitalise parts of a name containing different words, including those
+/// separated by hyphens.
+///
+/// For example, 'John-Doe'
+///
+/// # Parameters
+///
+/// * `name`: The name to parse
+///
+/// # Returns
+///
+/// The capitalized name
+#[must_use]
+pub fn cap(name: &str) -> String {
+    if name.is_empty() {
+        return name.to_string();
+    }
+
+    // Split the name by whitespace then hyphens, capitalizing each part then
+    // joining it back together.
+    let capitalized_name = name
+        .split_whitespace()
+        .map(|space_part| {
+            space_part
+                .split('-')
+                .map(|part| {
+                    let mut chars = part.chars();
+                    match chars.next() {
+                        None => String::new(),
+                        Some(first_char) => {
+                            let first_char_upper = first_char.to_uppercase().collect::<String>();
+                            let rest: String = chars.collect();
+                            format!("{}{}", first_char_upper, rest)
+                        }
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("-")
+        })
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    capitalized_name
+}
+
+/// Generate a Matrix ID localpart from an email address.
+///
+/// This function:
+/// 1. Replaces "@" with "-" in the email address
+/// 2. Converts the email to lowercase
+/// 3. Filters out any characters that are not allowed in a Matrix ID localpart
+///
+/// The allowed characters are: lowercase ASCII letters, digits, and "_-./="
+///
+/// # Parameters
+///
+/// * `address`: The email address to process
+///
+/// # Returns
+///
+/// A valid Matrix ID localpart derived from the email address
+#[must_use]
+pub fn email_to_mxid_localpart(address: &str) -> String {
+    // Define the allowed characters for a Matrix ID localpart
+    const ALLOWED_CHARS: &str = "abcdefghijklmnopqrstuvwxyz0123456789_-./=";
+    
+    // Replace "@" with "-" and convert to lowercase
+    let processed = address.replace('@', "-").to_lowercase();
+    
+    // Filter out any characters that are not allowed
+    processed.chars().filter(|c| ALLOWED_CHARS.contains(*c)).collect()
+}
+
+/// Generate a display name from an email address based on specific rules.
+///
+/// This function:
+/// 1. Replaces dots with spaces in the username part
+/// 2. Determines the organization based on domain rules:
+///    - matrix.org emails are marked as "Tchap Admin"
+///    - gouv.fr emails use the subdomain or "gouv" if none
+///    - other emails use the second-level domain
+/// 3. Returns a display name in the format "Username [Organization]"
+///
+/// # Parameters
+///
+/// * `address`: The email address to process
+///
+/// # Returns
+///
+/// The formatted display name
+#[must_use]
+pub fn email_to_display_name(address: &str) -> String {
+    // Split the part before and after the @ in the email.
+    // Replace all . with spaces in the first part
+    let parts: Vec<&str> = address.split('@').collect();
+    if parts.len() != 2 {
+        return String::new();
+    }
+    
+    let username = parts[0].replace('.', " ");
+    let domain = parts[1];
+
+    // Figure out which org this email address belongs to
+    let domain_parts: Vec<&str> = domain.split('.').collect();
+    
+    let org = if domain_parts.len() >= 2 && domain_parts[domain_parts.len() - 2] == "matrix" && domain_parts[domain_parts.len() - 1] == "org" {
+        // If this is a ...matrix.org email, mark them as an Admin
+        "Tchap Admin"
+    } else if domain_parts.len() >= 2 && domain_parts[domain_parts.len() - 2] == "gouv" && domain_parts[domain_parts.len() - 1] == "fr" {
+        // Is this is a ...gouv.fr address, set the org to whatever is before
+        // gouv.fr. If there isn't anything (a @gouv.fr email) simply mark their
+        // org as "gouv"
+        if domain_parts.len() > 2 {
+            domain_parts[domain_parts.len() - 3]
+        } else {
+            "gouv"
+        }
+    } else if domain_parts.len() >= 2 {
+        // Otherwise, mark their org as the email's second-level domain name
+        domain_parts[domain_parts.len() - 2]
+    } else {
+        ""
+    };
+
+    // Format the display name
+    format!("{} [{}]", cap(&username), cap(org))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cap() {
+        assert_eq!(cap("john"), "John");
+        assert_eq!(cap("john-doe"), "John-Doe");
+        assert_eq!(cap("john doe"), "John Doe");
+        assert_eq!(cap("john-doe smith"), "John-Doe Smith");
+        assert_eq!(cap(""), "");
+    }
+
+    #[test]
+    fn test_email_to_display_name() {
+        // Test matrix.org email
+        assert_eq!(
+            email_to_display_name("john.doe@matrix.org"),
+            "John Doe [Tchap Admin]"
+        );
+
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("jane.smith@example.gouv.fr"),
+            "Jane Smith [Example]"
+        );
+
+        // Test gouv.fr email without subdomain
+        assert_eq!(
+            email_to_display_name("user@gouv.fr"),
+            "User [Gouv]"
+        );
+
+        // Test regular email
+        assert_eq!(
+            email_to_display_name("contact@example.com"),
+            "Contact [Example]"
+        );
+
+        // Test invalid email
+        assert_eq!(email_to_display_name("invalid-email"), "");
+    }
+
+    #[test]
+    fn test_email_to_mxid_localpart() {
+        // Test basic email
+        assert_eq!(
+            email_to_mxid_localpart("john.doe@example.com"),
+            "john.doe-example.com"
+        );
+        
+        // Test with uppercase letters
+        assert_eq!(
+            email_to_mxid_localpart("John.Doe@Example.com"),
+            "john.doe-example.com"
+        );
+        
+        // Test with special characters
+        assert_eq!(
+            email_to_mxid_localpart("user+tag@domain.com"),
+            "usertag-domain.com"
+        );
+        
+        // Test with invalid characters
+        assert_eq!(
+            email_to_mxid_localpart("user!#$%^&*()@domain.com"),
+            "user-domain.com"
+        );
+    }
+}

--- a/tchap/README_TCHAP.md
+++ b/tchap/README_TCHAP.md
@@ -1,0 +1,16 @@
+## To run
+
+```
+./start-local-stack.sh
+./start-local-mas.sh
+```
+
+
+## Command helper 
+```
+#createdb -U postgres postgres
+# dropdb postgres
+#createdb -U postgres -O postgres keycloak
+#docker run -d -p 5432:5432 -e 'POSTGRES_USER=keycloak' -e 'POSTGRES_PASSWORD=keycloak' -e 'POSTGRES_DATABASE=keycloak' postgres-keycloak
+# cargo test --package mas-handlers upstream_oauth2::link::tests
+```

--- a/tchap/README_TCHAP.md
+++ b/tchap/README_TCHAP.md
@@ -1,3 +1,25 @@
+## Build 
+
+https://element-hq.github.io/matrix-authentication-service/setup/installation.html#building-from-the-source
+
+frontend 
+
+```
+cd frontend
+npm ci
+npm run build
+cd ..
+```
+
+
+policies
+```
+cd policies
+make DOCKER=1
+cd ..
+```
+
+
 ## To run
 
 ```

--- a/tchap/config.local.dev.yaml
+++ b/tchap/config.local.dev.yaml
@@ -1,0 +1,188 @@
+http:
+  listeners:
+    - name: web
+      resources:
+        - name: discovery
+        - name: human
+        - name: oauth
+        - name: compat
+        - name: graphql
+        - name: assets
+        - name: adminapi
+      binds:
+        - address: '[::]:8080'
+      proxy_protocol: false
+    - name: internal
+      resources:
+        - name: health
+        - name: adminapi
+      binds:
+        - host: localhost
+          port: 8081
+      proxy_protocol: false
+  trusted_proxies:
+    - 192.168.0.0/16
+    - 172.16.0.0/12
+    - 10.0.0.0/10
+    - 127.0.0.1/8
+    - fd00::/8
+    - ::1/128
+  #  public_base: http://[::]:8080/
+  #  issuer: http://[::]:8080/
+  public_base: https://auth.tchapgouv.com/
+  issuer: https://auth.tchapgouv.com/
+database:
+  uri: postgresql://postgres:postgres@localhost/postgres
+  max_connections: 10
+  min_connections: 0
+  connect_timeout: 30
+  idle_timeout: 600
+  max_lifetime: 1800
+email:
+  from: '"Authentication Service" <auth@tchapgouv.com>'
+  reply_to: '"Authentication Service" <auth@tchapgouv.com>'
+  transport: smtp
+  mode: plain
+  hostname: 127.0.0.1
+  port: 1025
+
+secrets:
+  encryption: eb38b8b9087842b3345269f3c6ca92b2a8d6aa63e3a773d23ed1c9cb45c5ef83
+  keys:
+    - kid: dyrZtIyXSA
+      key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEogIBAAKCAQEAukLyWSv9KOeBsmIG4ntL/BP+wj5L4GbOyAOEzRBBO0ZbBYVn
+        1L/aYQ65cQpQKK0MzH5cn7TvIY0JBh/ZsSm3e7DdhGJzoqPrW6E0/6QqXEl4gN1q
+        DUCMj2CwAcT9OX1Wt6cNq70+gbqp6+yT+Nn++KPylHa/V9wRxkaV3fyM+XYVeddB
+        amDR+fBjHgVXQ3xk2ezUBS3AmyKBgETnHufKCkxJ5mXdU9HT0ewg8J2PrgiRBwDj
+        XP7C5Zif/+NfYPO2mM/b0Y91pl9aXuUHX+/zlqtpcwX/WprEsCaRUa9qWHuiftMf
+        uelsflCgZ0KumZjzr3wPDEfu8n7WbVEObNxF+QIDAQABAoIBAEl82mNGUMbPuEMq
+        G+9FmDAnr27x5zvtNA6EHORPUn1Rf94IyXOOEloS1iV8XS3/QLp57I9ycpq5K2NI
+        M7qLbAIYQP3XXipAJD7ttpxaKABrWGj3cr0xx4NWMXsxPnttMUaaWXF14/CJNjuI
+        BsW7NLbi8HWU+F9wy26AMOb5mqFdQfk15H3LaM3L3hMuV5DOcA467luwHmuGGTji
+        VjZg3yZZF2ROtTwwVSB7UCokmW3FZys/U4SyzXSrboUxF9T3PW3Hxm9e1JfFQuLh
+        rn85Q4IDpRtK2O5ECmKjY0cyvQOVItQytTeVXtSEzgMfK5VpnYMefdCFvhExcsuV
+        JHT1c/UCgYEAziAPCJYNTXsvo3yEW1iWnAjfi6R7g9aluNDjf4xmva5DTOdZSH1d
+        AJkzXZtPYXXlR42RT4FzE/ICdjo81aDMrMHwoIiH9p1n7IdDTt3GONYi3VPKGvZd
+        Ghgdq5jgdedDhF9MximZcWdZOZLCymKME61RuCg18p/MMIJ/FRNBE38CgYEA51R6
+        CjNc93qO7hL7AGu+evs3/PVrHsg5iBf8GcGeyNNGkA5TJcYTO075VBDQuWsMZbvx
+        d0jBjROs8U2AJzgbh6+N/rZACflk8W4LyD3Pw+1coIcckH4hmgN37vkh63qiGX8K
+        YVe8CrbGliBB2OccXsdJVDe0f45kte0eJh6cAocCgYAH9d7+wuTCoEZHtxBZgsNW
+        RVV0zCZlAg4mZBLVIzP4kVlSCAE/tm+4DTKZo9zd87KmH8aD3oj2NTt5G2isC2i8
+        J0VGvd8aXBveW57y1cfI/CQejhTZE7imwFWtAdtxUjweSZvqb0LYyVf9zDgvnryw
+        KdplFVB4DUnSece0pai2uwKBgDzV335dQZ6nsXz0quPScfZ/qJqyo+gledPLkvXn
+        EG35+f2ads1hSN95BmLQRUPt3gXHJlpbXONQAFQ5MHGf9MV7KpmIrlCxMJW5fgm8
+        D66T9p8UyTNKqGWLcff7tqrpxkV0PnOZEg+zP4htlUOIi9J1EFjAiYxeEygw4pPd
+        yuNzAoGAI0lLE32iIm+j5byFCKRuS6cQmDBzUJxZiCuLsuZEINYdz2nxKZqd9VtA
+        rOXzo8vJuGLF1hjf1/C66F3EnPxcclPL10vLCE8RbfQYVwBxw7MG9BLJXIlMjb2V
+        7CjVDE4Gaa96tChg1pepuJcOEuWez3o3Ard9oZ4Z9sm7VJzmuoY=
+        -----END RSA PRIVATE KEY-----
+    - kid: O1hkajPW2v
+      key: |
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEINsgMBFDIrIzqOIWuR94TCi5MTH1FS8wfgatu9BsO2jVoAoGCCqGSM49
+        AwEHoUQDQgAEldEtvZaXtblpUdHpKKQiH7z9ADC55H0yrCYyQsLXbt14lI2NuseX
+        MWsvSLBzkbEetDxkmKh0bhOfrdwv9x5SwA==
+        -----END EC PRIVATE KEY-----
+    - kid: 2nhe3z2925
+      key: |
+        -----BEGIN EC PRIVATE KEY-----
+        MIGkAgEBBDDTVngHypOwUnPOGXeskQJhdSLLPBCM+mkSvzr2SZ7Kjm3hftvs2s7J
+        gZBOZwXyoaKgBwYFK4EEACKhZANiAAQ3WGOQs3EqO2x4X7PBWs6Lw3qdmRLHqblc
+        Zplh3wYPDOoUMvD99Snxz43t5sK6kphLBL262/srx/UPT1McLUxBMlBvBUbBEKHX
+        a8icrL13yIwflquj0EHrE7czFJw1txs=
+        -----END EC PRIVATE KEY-----
+    - kid: 50aRR3QVqx
+      key: |
+        -----BEGIN EC PRIVATE KEY-----
+        MHQCAQEEIN8bErXY1sWEJ1y9KoYcpcUImIjpS/ay3pEugYPfr3Y/oAcGBSuBBAAK
+        oUQDQgAEMHcshHVFbMSEyyt3ptIdAhnrg+XlQskZ33hZvdtzm6I0wW8H8zslMp+I
+        t0KYCeIQ7HTPtgJAOsKxEPBfmVXZmA==
+        -----END EC PRIVATE KEY-----
+passwords:
+  enabled: true
+  schemes:
+    - version: 1
+      algorithm: bcrypt
+      secret: "secret01"
+    - version: 2
+      algorithm: argon2id
+  minimum_complexity: 3
+matrix:
+  homeserver: tchapgouv.com
+  secret: '/DjWc4D3yyqgjYN8tum65g'
+  endpoint: https://matrix.tchapgouv.com/
+
+clients:
+  - client_id: 0000000000000000000SYNAPSE
+    client_auth_method: client_secret_basic
+    client_secret: '/DjWc4D3yyqgjYN8tum65g'
+
+account:
+  # Whether users are allowed to change their email addresses.
+  #
+  # Defaults to `true`.
+  email_change_allowed: false
+
+  # Whether users are allowed to change their display names
+  #
+  # Defaults to `true`.
+  # This should be in sync with the policy in the homeserver configuration.
+  displayname_change_allowed: false
+
+  # Whether to enable self-service password registration
+  #
+  # Defaults to `false`.
+  # This has no effect if password login is disabled.
+  password_registration_enabled: true
+
+  # Whether users are allowed to change their passwords
+  #
+  # Defaults to `true`.
+  # This has no effect if password login is disabled.
+  password_change_allowed: true
+
+  # Whether email-based password recovery is enabled
+  #
+  # Defaults to `false`.
+  # This has no effect if password login is disabled.
+  password_recovery_enabled: true
+
+  allow_login_by_email: true
+
+#templates:
+  # From where to load the templates
+  # This is relative to the current working directory, *not* the config file
+#  path: /Users/mca/Documents/work/projets/betagouv/repo/matrix-authentication-service/templates2
+
+#  # Path to the frontend assets manifest file
+#  assets_manifest: /to/manifest.json
+#
+#  # From where to load the translation files
+#  # Default in Docker distribution: `/usr/local/share/mas-cli/translations/`
+#  # Default in pre-built binaries: `./share/translations/`
+#  # Default in locally-built binaries: `./translations/`
+#  translations_path: /to/translations
+
+
+upstream_oauth2:
+  providers:
+    - id: "01JK5MR1SD21MAQY4PWMFG283W"
+      issuer: "https://tchap-connect.tchapgouv.com/realms/tchap"
+      token_endpoint_auth_method: client_secret_basic
+      client_id: "matrix-authentication-service"
+      client_secret: "HrJ1NZ0AbkHuWWjyRHh7X2lzn3S8eagt"
+      scope: "openid profile email"
+      claims_imports:
+        localpart:
+          action: force
+          template: "{{ user.preferred_username }}"
+        displayname:
+          action: force
+          template: "{{ user.name }}"
+        email:
+          action: force
+          template: "{{ user.email }}"
+          set_email_verification: always
+      allow_existing_users: true

--- a/tchap/config.local.dev.yaml
+++ b/tchap/config.local.dev.yaml
@@ -118,6 +118,18 @@ clients:
   - client_id: 0000000000000000000SYNAPSE
     client_auth_method: client_secret_basic
     client_secret: '/DjWc4D3yyqgjYN8tum65g'
+  
+  # for api admin calls
+  - client_id: 01J44RKQYM4G3TNVANTMTDYTX6
+    client_auth_method: client_secret_basic
+    client_secret: phoo8ahneir3ohY2eigh4xuu6Oodaewi
+
+
+policy:
+  data:
+    admin_clients:
+      # for api admin calls
+      - 01J44RKQYM4G3TNVANTMTDYTX6
 
 account:
   # Whether users are allowed to change their email addresses.
@@ -166,23 +178,23 @@ account:
 #  translations_path: /to/translations
 
 
-upstream_oauth2:
-  providers:
-    - id: "01JK5MR1SD21MAQY4PWMFG283W"
-      issuer: "https://tchap-connect.tchapgouv.com/realms/tchap"
-      token_endpoint_auth_method: client_secret_basic
-      client_id: "matrix-authentication-service"
-      client_secret: "HrJ1NZ0AbkHuWWjyRHh7X2lzn3S8eagt"
-      scope: "openid profile email"
-      claims_imports:
-        localpart:
-          action: force
-          template: "{{ user.preferred_username }}"
-        displayname:
-          action: force
-          template: "{{ user.name }}"
-        email:
-          action: force
-          template: "{{ user.email }}"
-          set_email_verification: always
-      allow_existing_users: true
+# upstream_oauth2:
+#   providers:
+#     - id: "01JK5MR1SD21MAQY4PWMFG283W"
+#       issuer: "https://tchap-connect.tchapgouv.com/realms/tchap"
+#       token_endpoint_auth_method: client_secret_basic
+#       client_id: "matrix-authentication-service"
+#       client_secret: "HrJ1NZ0AbkHuWWjyRHh7X2lzn3S8eagt"
+#       scope: "openid profile email"
+#       claims_imports:
+#         localpart:
+#           action: force
+#           template: "{{ user.preferred_username }}"
+#         displayname:
+#           action: force
+#           template: "{{ user.name }}"
+#         email:
+#           action: force
+#           template: "{{ user.email }}"
+#           set_email_verification: always
+#       allow_existing_users: true

--- a/tchap/pre-commit-check.sh
+++ b/tchap/pre-commit-check.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+# cd ..
+# ./misc/update.sh
+# cargo +nightly fmt 
+# export DATABASE_URL=postgresql://postgres:postgres@localhost/postgres
+# cargo test --workspace
+# unset DATABASE_URL
+# cargo clippy --workspace --tests --bins --lib -- -D warnings

--- a/tchap/start-local-mas.sh
+++ b/tchap/start-local-mas.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+cargo run -- server -c tchap/config.local.dev.yaml

--- a/tchap/start-local-stack.sh
+++ b/tchap/start-local-stack.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Run mail service
+docker rm -f mailcatcher
+docker run -d --name mailcatcher -p 1080:1080 -p 1025:1025 sj26/mailcatcher
+# Run postgres service
+#createdb -U postgres postgres
+# dropdb postgres
+docker rm -f postgres
+docker run -d --name postgres -p 5432:5432 -v ./tchap/postgres:/var/lib/postgresql/data:rw -e 'POSTGRES_USER=postgres' -e 'POSTGRES_PASSWORD=postgres' -e 'POSTGRES_DATABASE=postgres' -e 'PGDATA=/var/lib/postgresql/data' postgres
+#createdb -U postgres -O postgres keycloak
+#docker run -d -p 5432:5432 -e 'POSTGRES_USER=keycloak' -e 'POSTGRES_PASSWORD=keycloak' -e 'POSTGRES_DATABASE=keycloak' postgres-keycloak
+#cargo run -- server -c config.local.dev.yaml
+# cargo test --package mas-handlers upstream_oauth2::link::tests

--- a/tchap/test_admin.sh
+++ b/tchap/test_admin.sh
@@ -1,0 +1,20 @@
+
+CLIENT_ID=01J44RKQYM4G3TNVANTMTDYTX6
+CLIENT_SECRET=phoo8ahneir3ohY2eigh4xuu6Oodaewi
+#MAS_HOST=localhost:8080
+MAS_HOST=auth.tchapgouv.com
+
+ACCESS_TOKEN=$(curl \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=client_credentials&scope=urn:mas:admin" \
+  https://$MAS_HOST/oauth2/token \
+  | jq -r '.access_token')
+
+echo $ACCESS_TOKEN
+
+# List users (The -g flag prevents curl from interpreting the brackets in the URL)
+curl \
+   -g \
+   -H "Authorization: Bearer $ACCESS_TOKEN" \
+   "https://$MAS_HOST/api/admin/v1/users?filter[can_request_admin]=true&filter[status]=active&page[first]=100" \
+   | jq


### PR DESCRIPTION
add custom jinja filters for generating display name and localpart

configuration exemple for oidc  : 


```
upstream_oauth2:
  providers:
    - id: "01JK5MR1SD21MAQY4PWMFG283W"
      human_name: Proconnect (mock)
      issuer: "http://localhost:8082/realms/proconnect-mock"
      token_endpoint_auth_method: client_secret_basic
      client_id: "mas"
      client_secret: "HrJ1NZ0AbkHuWWjyRHh7X2lzn3S8eagt"
      scope: "openid profile email"
      claims_imports:
        localpart:
          action: require 
          template: "{{ user.email | email_to_mxid_localpart }}"
        displayname:
          action: require
          template: "{{ user.email | email_to_display_name }}"
        email:
          action: require
          template: "{{ user.email }}"
          set_email_verification: always
```
