### PR TITLE
add filters for legacy email and legacy localpart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,6 +3352,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "sqlx",
+ "tchap",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -6225,6 +6226,10 @@ name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "tchap"
+version = "0.1.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ mas-templates = { path = "./crates/templates/", version = "=0.16.0" }
 mas-tower = { path = "./crates/tower/", version = "=0.16.0" }
 oauth2-types = { path = "./crates/oauth2-types/", version = "=0.16.0" }
 syn2mas = { path = "./crates/syn2mas", version = "=0.16.0" }
+tchap = { path = "./crates/tchap", version = "=0.1.0" }
 
 # OpenAPI schema generation and validation
 [workspace.dependencies.aide]

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -107,6 +107,8 @@ mas-templates.workspace = true
 oauth2-types.workspace = true
 zxcvbn = "3.1.0"
 
+tchap.workspace = true
+
 [dev-dependencies]
 insta.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/handlers/src/upstream_oauth2/template.rs
+++ b/crates/handlers/src/upstream_oauth2/template.rs
@@ -11,6 +11,7 @@ use minijinja::{
     Environment, Error, ErrorKind, Value,
     value::{Enumerator, Object},
 };
+use tchap;
 
 /// Context passed to the attribute mapping template
 ///
@@ -187,6 +188,16 @@ pub fn environment() -> Environment<'static> {
     env.add_filter("tlvdecode", tlvdecode);
     env.add_filter("string", string);
     env.add_filter("from_json", from_json);
+
+    // Add Tchap-specific filters, this could be a generic config submitted
+    // to upstream allowing all users to add their own filters without upstream code
+    // modifications tester les fonctions async pour le reseau
+    env.add_filter("email_to_display_name", |s: &str| {
+        tchap::email_to_display_name(s)
+    });
+    env.add_filter("email_to_mxid_localpart", |s: &str| {
+        tchap::email_to_mxid_localpart(s)
+    });
 
     env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
 

--- a/crates/tchap/Cargo.toml
+++ b/crates/tchap/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tchap"
+version = "0.1.0"
+description = "Tchap-specific functionality for Matrix Authentication Service"
+license = "MIT"
+
+[dependencies]

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -1,0 +1,210 @@
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+//! Tchap-specific functionality for Matrix Authentication Service
+
+/// Capitalise parts of a name containing different words, including those
+/// separated by hyphens.
+///
+/// For example, 'John-Doe'
+///
+/// # Parameters
+///
+/// * `name`: The name to parse
+///
+/// # Returns
+///
+/// The capitalized name
+#[must_use]
+pub fn cap(name: &str) -> String {
+    if name.is_empty() {
+        return name.to_string();
+    }
+
+    // Split the name by whitespace then hyphens, capitalizing each part then
+    // joining it back together.
+    let capitalized_name = name
+        .split_whitespace()
+        .map(|space_part| {
+            space_part
+                .split('-')
+                .map(|part| {
+                    let mut chars = part.chars();
+                    match chars.next() {
+                        None => String::new(),
+                        Some(first_char) => {
+                            let first_char_upper = first_char.to_uppercase().collect::<String>();
+                            let rest: String = chars.collect();
+                            format!("{}{}", first_char_upper, rest)
+                        }
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("-")
+        })
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    capitalized_name
+}
+
+/// Generate a Matrix ID localpart from an email address.
+///
+/// This function:
+/// 1. Replaces "@" with "-" in the email address
+/// 2. Converts the email to lowercase
+/// 3. Filters out any characters that are not allowed in a Matrix ID localpart
+///
+/// The allowed characters are: lowercase ASCII letters, digits, and "_-./="
+///
+/// # Parameters
+///
+/// * `address`: The email address to process
+///
+/// # Returns
+///
+/// A valid Matrix ID localpart derived from the email address
+#[must_use]
+pub fn email_to_mxid_localpart(address: &str) -> String {
+    // Define the allowed characters for a Matrix ID localpart
+    const ALLOWED_CHARS: &str = "abcdefghijklmnopqrstuvwxyz0123456789_-./=";
+
+    // Replace "@" with "-" and convert to lowercase
+    let processed = address.replace('@', "-").to_lowercase();
+
+    // Filter out any characters that are not allowed
+    processed
+        .chars()
+        .filter(|c| ALLOWED_CHARS.contains(*c))
+        .collect()
+}
+
+/// Generate a display name from an email address based on specific rules.
+///
+/// This function:
+/// 1. Replaces dots with spaces in the username part
+/// 2. Determines the organization based on domain rules:
+///    - gouv.fr emails use the subdomain or "gouv" if none
+///    - other emails use the second-level domain
+/// 3. Returns a display name in the format "Username [Organization]"
+///
+/// # Parameters
+///
+/// * `address`: The email address to process
+///
+/// # Returns
+///
+/// The formatted display name
+#[must_use]
+pub fn email_to_display_name(address: &str) -> String {
+    // Split the part before and after the @ in the email.
+    // Replace all . with spaces in the first part
+    let parts: Vec<&str> = address.split('@').collect();
+    if parts.len() != 2 {
+        return String::new();
+    }
+
+    let username = parts[0].replace('.', " ");
+    let domain = parts[1];
+
+    // Figure out which org this email address belongs to
+    let domain_parts: Vec<&str> = domain.split('.').collect();
+
+    let org = if domain_parts.len() >= 2
+        && domain_parts[domain_parts.len() - 2] == "gouv"
+        && domain_parts[domain_parts.len() - 1] == "fr"
+    {
+        // Is this is a ...gouv.fr address, set the org to whatever is before
+        // gouv.fr. If there isn't anything (a @gouv.fr email) simply mark their
+        // org as "gouv"
+        if domain_parts.len() > 2 {
+            domain_parts[domain_parts.len() - 3]
+        } else {
+            "gouv"
+        }
+    } else if domain_parts.len() >= 2 {
+        // Otherwise, mark their org as the email's second-level domain name
+        domain_parts[domain_parts.len() - 2]
+    } else {
+        ""
+    };
+
+    // Format the display name
+    format!("{} [{}]", cap(&username), cap(org))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cap() {
+        assert_eq!(cap("john"), "John");
+        assert_eq!(cap("john-doe"), "John-Doe");
+        assert_eq!(cap("john doe"), "John Doe");
+        assert_eq!(cap("john-doe smith"), "John-Doe Smith");
+        assert_eq!(cap(""), "");
+    }
+
+    #[test]
+    fn test_email_to_display_name() {
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("jane.smith@example.gouv.fr"),
+            "Jane Smith [Example]"
+        );
+
+        // Test gouv.fr email without subdomain
+        assert_eq!(email_to_display_name("user@gouv.fr"), "User [Gouv]");
+
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("user@gendarmerie.gouv.fr"),
+            "User [Gendarmerie]"
+        );
+
+        // Test gouv.fr email with subdomain
+        assert_eq!(
+            email_to_display_name("user@gendarmerie.interieur.gouv.fr"),
+            "User [Interieur]"
+        );
+
+        // Test regular email
+        assert_eq!(
+            email_to_display_name("contact@example.com"),
+            "Contact [Example]"
+        );
+
+        // Test invalid email
+        assert_eq!(email_to_display_name("invalid-email"), "");
+    }
+
+    #[test]
+    fn test_email_to_mxid_localpart() {
+        // Test basic email
+        assert_eq!(
+            email_to_mxid_localpart("john.doe@example.com"),
+            "john.doe-example.com"
+        );
+
+        // Test with uppercase letters
+        assert_eq!(
+            email_to_mxid_localpart("John.Doe@Example.com"),
+            "john.doe-example.com"
+        );
+
+        // Test with special characters
+        assert_eq!(
+            email_to_mxid_localpart("user+tag@domain.com"),
+            "usertag-domain.com"
+        );
+
+        // Test with invalid characters
+        assert_eq!(
+            email_to_mxid_localpart("user!#$%^&*()@domain.com"),
+            "user-domain.com"
+        );
+    }
+}


### PR DESCRIPTION
add custom jinja filters for generating display name and localpart

configuration exemple for oidc :
```
upstream_oauth2:
  providers:
    - id: "01JK5MR1SD21MAQY4PWMFG283W"
      human_name: Proconnect (mock)
      issuer: "http://localhost:8082/realms/proconnect-mock"
      token_endpoint_auth_method: client_secret_basic
      client_id: "mas"
      client_secret: "HrJ1NZ0AbkHuWWjyRHh7X2lzn3S8eagt"
      scope: "openid profile email"
      claims_imports:
        localpart:
          action: require 
          template: "{{ user.email | email_to_mxid_localpart }}"
        displayname:
          action: require
          template: "{{ user.email | email_to_display_name }}"
        email:
          action: require
          template: "{{ user.email }}"
          set_email_verification: always
```