### PR TITLE
add error when email is not allowed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6230,6 +6230,14 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 [[package]]
 name = "tchap"
 version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "tempfile"

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -36,10 +36,13 @@ use mas_templates::{
 use minijinja::Environment;
 use opentelemetry::{Key, KeyValue, metrics::Counter};
 use serde::{Deserialize, Serialize};
+//:tchap:
+use tchap::{self, EmailAllowedResult};
 use thiserror::Error;
 use tracing::warn;
 use ulid::Ulid;
 
+//:tchap: end
 use super::{
     UpstreamSessionsCookie,
     template::{AttributeMappingContext, environment},
@@ -442,7 +445,48 @@ pub(crate) async fn get(
                     &context,
                     provider.claims_imports.email.is_required(),
                 )? {
-                    Some(value) => ctx.with_email(value, provider.claims_imports.email.is_forced()),
+                    Some(value) => {
+                        //:tchap:
+                        let server_name = homeserver.homeserver();
+                        let email_result = check_email_allowed(&value, server_name).await;
+
+                        match email_result {
+                            EmailAllowedResult::Allowed => {
+                                // Email is allowed, continue
+                            }
+                            EmailAllowedResult::WrongServer => {
+                                // Email is mapped to a different server
+                                let ctx = ErrorContext::new()
+                                    .with_code("wrong_server")
+                                    .with_description(format!("Votre adresse mail {value} est associée à un autre serveur."))
+                                    .with_details("Veuillez-vous contacter le support de Tchap support@tchap.beta.gouv.fr".to_owned())
+                                    .with_language(&locale);
+
+                                //return error template
+                                return Ok((
+                                    cookie_jar,
+                                    Html(templates.render_error(&ctx)?).into_response(),
+                                ));
+                            }
+                            EmailAllowedResult::InvitationMissing => {
+                                // Server requires an invitation that is not present
+                                let ctx = ErrorContext::new()
+                                    .with_code("invitation_missing")
+                                    .with_description("Vous avez besoin d'une invitation pour accéder à Tchap.".to_owned())
+                                    .with_details("Les partenaires externes peuvent accéder à Tchap uniquement avec une invitation d'un agent public.".to_owned())
+                                    .with_language(&locale);
+
+                                //return error template
+                                return Ok((
+                                    cookie_jar,
+                                    Html(templates.render_error(&ctx)?).into_response(),
+                                ));
+                            }
+                        }
+                        //:tchap: end
+
+                        ctx.with_email(value, provider.claims_imports.email.is_forced())
+                    }
                     None => ctx,
                 }
             };
@@ -895,6 +939,19 @@ pub(crate) async fn post(
 
     Ok((cookie_jar, post_auth_action.go_next(&url_builder)).into_response())
 }
+
+//:tchap:
+///real function used when not testing
+#[cfg(not(test))]
+async fn check_email_allowed(email: &str, server_name: &str) -> EmailAllowedResult {
+    tchap::is_email_allowed(email, server_name).await
+}
+///mock function used when testing
+#[cfg(test)]
+async fn check_email_allowed(_email: &str, _server_name: &str) -> EmailAllowedResult {
+    EmailAllowedResult::Allowed
+}
+//:tchap:end
 
 #[cfg(test)]
 mod tests {

--- a/crates/tchap/Cargo.toml
+++ b/crates/tchap/Cargo.toml
@@ -3,5 +3,13 @@ name = "tchap"
 version = "0.1.0"
 description = "Tchap-specific functionality for Matrix Authentication Service"
 license = "MIT"
+edition = "2024"
+
 
 [dependencies]
+reqwest.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+url.workspace = true
+serde.workspace = true

--- a/crates/tchap/src/identity_client.rs
+++ b/crates/tchap/src/identity_client.rs
@@ -1,0 +1,77 @@
+//! This module provides utilities for interacting with the Matrix identity
+//! server API.
+
+use std::time::Duration;
+
+use tracing::info;
+use url::Url;
+
+fn default_identity_server_url() -> Url {
+    // Try to read the TCHAP_IDENTITY_SERVER_URL environment variable
+    match std::env::var("TCHAP_IDENTITY_SERVER_URL") {
+        Ok(url_str) => {
+            // Attempt to parse the URL from the environment variable
+            match Url::parse(&url_str) {
+                Ok(url) => {
+                    // Success: use the URL from the environment variable
+                    return url;
+                }
+                Err(err) => {
+                    // Parsing error: log a warning and use the default value
+                    tracing::warn!(
+                        "The TCHAP_IDENTITY_SERVER_URL environment variable contains an invalid URL: {}. Using default value.",
+                        err
+                    );
+                }
+            }
+        }
+        Err(std::env::VarError::NotPresent) => {
+            // Variable not defined: use the default value without warning
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            // Variable contains non-Unicode characters: log a warning
+            tracing::warn!(
+                "The TCHAP_IDENTITY_SERVER_URL environment variable contains non-Unicode characters. Using default value."
+            );
+        }
+    }
+
+    // Default value if the environment variable is not defined or invalid
+    Url::parse("http://localhost:8090").unwrap()
+}
+
+/// Queries the identity server for information about an email address
+///
+/// # Parameters
+///
+/// * `email`: The email address to check///
+/// # Returns
+///
+/// A Result containing either the JSON response or an error
+pub async fn query_identity_server(email: &str) -> Result<serde_json::Value, reqwest::Error> {
+    let identity_server_url = default_identity_server_url();
+
+    // Construct the URL with the email address
+    let url = format!(
+        "{}_matrix/identity/api/v1/internal-info?medium=email&address={}",
+        identity_server_url, email
+    );
+
+    info!("Making request to identity server: {}", url);
+
+    // Create a client with a timeout
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
+
+    // Make the HTTP request asynchronously
+    // should use mas-http instead like SynapseConnection
+    #[allow(clippy::disallowed_methods)]
+    let response = client.get(&url).send().await?;
+
+    // Parse the JSON response
+    let json = response.json::<serde_json::Value>().await?;
+
+    Ok(json)
+}

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -5,6 +5,11 @@
 
 //! Tchap-specific functionality for Matrix Authentication Service
 
+extern crate tracing;
+use tracing::info;
+
+mod identity_client;
+
 /// Capitalise parts of a name containing different words, including those
 /// separated by hyphens.
 ///
@@ -133,6 +138,76 @@ pub fn email_to_display_name(address: &str) -> String {
 
     // Format the display name
     format!("{} [{}]", cap(&username), cap(org))
+}
+
+/// Result of checking if an email is allowed on a server
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmailAllowedResult {
+    /// Email is allowed on this server
+    Allowed,
+    /// Email is mapped to a different server
+    WrongServer,
+    /// Server requires an invitation that is not present
+    InvitationMissing,
+}
+
+/// Checks if an email address is allowed to be associated in the current server
+///
+/// This function makes an asynchronous GET request to the Matrix identity
+/// server API to retrieve information about the home server associated with an
+/// email address, then applies logic to determine if the email is allowed.
+///
+/// # Parameters
+///
+/// * `email`: The email address to check
+/// * `server_name`: The name of the server to check against
+///
+/// # Returns
+///
+/// An `EmailAllowedResult` indicating whether the email is allowed and if not,
+/// why
+#[must_use]
+pub async fn is_email_allowed(email: &str, server_name: &str) -> EmailAllowedResult {
+    // Query the identity server
+    match identity_client::query_identity_server(email).await {
+        Ok(json) => {
+            let hs = json.get("hs");
+
+            // Check if "hs" is in the response or if hs different from server_name
+            if hs.is_none() || hs.unwrap() != server_name {
+                // Email is mapped to a different server or no server at all
+                return EmailAllowedResult::WrongServer;
+            }
+
+            info!("hs: {} ", hs.unwrap());
+
+            // Check if requires_invite is true and invited is false
+            let requires_invite = json
+                .get("requires_invite")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let invited = json
+                .get("invited")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            info!("requires_invite: {} invited: {}", requires_invite, invited);
+
+            if requires_invite && !invited {
+                // Requires an invite but hasn't been invited
+                return EmailAllowedResult::InvitationMissing;
+            }
+
+            // All checks passed
+            EmailAllowedResult::Allowed
+        }
+        Err(err) => {
+            // Log the error and return WrongServer as a default error
+            eprintln!("HTTP request failed: {}", err);
+            EmailAllowedResult::WrongServer
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As other methods failed, I injected custom code into the link handler to raise an error.

 Tested with e2e tests with mock sydent and mock proconnect (keycloak) :  

https://github.com/tchapgouv/matrix-authentication-service-tchap/pull/1
- homeserver is valid  🟢
- external user has an invite 🟢
- external user has no invite 🟢
- homeserver is wrong 🟢

### account is created
![image](https://github.com/user-attachments/assets/22c68a5e-53cc-4690-b45e-f077f97423bd)

![image](https://github.com/user-attachments/assets/4815d39f-8b87-46e2-a857-53c1d7c5b0b1)


### external user has no invite
![image](https://github.com/user-attachments/assets/4b878198-4812-40c1-b565-e2ce88a3df24)

### home server is wrong

![image](https://github.com/user-attachments/assets/37a46f4e-f645-4325-a98c-7b6ba56e8eb5)


