### PR TITLE
fix/ prococonnect button should not raise a form error

### DIFF
--- a/tchap/resources/templates/pages/login.html
+++ b/tchap/resources/templates/pages/login.html
@@ -40,7 +40,7 @@ Please see LICENSE in the repository root for full details.
 
     <!-- #tchap# add .lasuite class to add lasuite fonts -->
     <div class="cpd-form-root lasuite">
-      <button class="proconnect-button" onclick="window.location.href = '{{ ('/upstream/authorize/' ~ provider.id ~ params) | prefix_url }}';">
+      <button class="proconnect-button" onclick="window.location.href = '{{ ('/upstream/authorize/' ~ provider.id ~ params) | prefix_url }}';return false;">
           <span class="proconnect-sr-only">S'identifier avec ProConnect</span>
         </button>
         <p>


### PR DESCRIPTION
Fix this bug:
- when clicking on the proconnect button this message shows
<img width="389" height="588" alt="image" src="https://github.com/user-attachments/assets/0e425432-11ba-47a8-acd4-81679c77ba2d" />
