### PR TITLE
enforce upstream account matching only by email

### DIFF
--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -525,7 +525,7 @@ pub(crate) async fn get(
                         // form, but this lead to poor UX. This is why we do
                         // it ahead of time here.
                         //:tchap:
-                        //the only ustream account matching is based on the email
+                        //the only upstream account matching is based on the email
                         let template = provider
                             .claims_imports
                             .email
@@ -561,7 +561,8 @@ pub(crate) async fn get(
                                 return Err(RouteError::InvalidFormAction);
                             };
                             //:tchap:
-                            let maybe_existing_user = repo.user().find_by_username(&localpart).await?;
+                            let maybe_existing_user =
+                                repo.user().find_by_username(&localpart).await?;
 
                             if let Some(existing_user) = maybe_existing_user {
                                 let email = &repo
@@ -820,7 +821,7 @@ pub(crate) async fn post(
                 provider.claims_imports.email.is_required(),
             );
 
-            let mut maybe_user = if let Ok(Some(email)) = maybe_email {
+            let maybe_user = if let Ok(Some(email)) = maybe_email {
                 tchap::search_user_by_email(&mut repo, &email, &tchap_config).await?
             } else {
                 None


### PR DESCRIPTION
In Tchap upstream account linking is based firstly on `sub` and secondary on `email`. We do not match by username. While in MAS, matching is done by username.

If email is not found, we do not want to extend searching by username. why? 

- if search by username hit a result while searching by email doesn't, it means we have incorrect data : email is not bound to username in Tchap database. We'd rather show an error so that users contact the support. 


E2E test : https://github.com/tchapgouv/matrix-authentication-service-tchap/pull/18

<img width="645" height="510" alt="image" src="https://github.com/user-attachments/assets/1d1fef57-6c57-4333-ae75-2449421aa1e6" />






