### PR TITLE
:TCHAP: End session - Reply with a Redirect when implicit check failed

### DIFF
--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -138,16 +138,6 @@ pub(crate) async fn get(
         return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
     }
 
-    // Check that the client ending the session is the same as the client that
-    // created it.
-    if client.id != oauth_session.client_id {
-        info!(
-            "Invalid client id [browser session id={}, oauth2 session id: {}, client id: {}]",
-            browser_session_id, oauth_session.id, client.id
-        );
-        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
-    }
-
     activity_tracker
         .record_oauth2_session(&clock, &oauth_session)
         .await;
@@ -235,7 +225,7 @@ mod tests {
 
         let ClientRegistrationResponse { client_id, .. } = response.json();
 
-        // Provision a provider and a link
+        // Create a user and its browser session
         let mut repo = state.repository().await.unwrap();
         let user = repo
             .user()
@@ -248,7 +238,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Lookup the client in the database.
+        // Lookup the client in the database and add oauth2 session
         let client = repo
             .oauth2_client()
             .find_by_client_id(&client_id)
@@ -268,14 +258,11 @@ mod tests {
             .unwrap();
         repo.save().await.unwrap();
 
-        // Grab a key to sign the id_token
-        // We could generate a key on the fly, but because we have one available here,
-        // why not use it?
+        // Generate id_token
         let exp = state.clock.now() + Duration::minutes(10);
         let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
             "sub": user.id,
-            // "sid": sid,
             "aud": client_id,
             "exp": exp.timestamp(),
             "iat": iat.timestamp(),
@@ -337,7 +324,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    async fn test_end_sessions_with_no_browser_session(pool: PgPool) {
+    async fn test_end_sessions_with_no_existing_oauth2_session(pool: PgPool) {
         setup();
         let state = TestState::from_pool(pool).await.unwrap();
         let mut rng = state.rng();
@@ -358,7 +345,178 @@ mod tests {
 
         let ClientRegistrationResponse { client_id, .. } = response.json();
 
-        // Provision a provider and a link
+        // Create a user and its browser session
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let browser_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
+            .await
+            .unwrap();
+
+        // We do not add any oauth2 session...
+
+        repo.save().await.unwrap();
+
+        // Generate id_token
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            "aud": client_id,
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            "iss": "https://example.com/",
+        });
+
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let mut cookie_jar = state.cookie_jar();
+        let info = SessionInfo::from_session(&browser_session);
+        cookie_jar = cookie_jar.update_session_info(&info);
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
+        };
+
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions_with_client_with_no_response_algorithm(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                // We do not define any response algorithm
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Create a user and its browser session
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+
+        let browser_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
+            .await
+            .unwrap();
+
+        // Lookup the client in the database and add oauth2 session
+        repo.oauth2_client()
+            .find_by_client_id(&client_id)
+            .await
+            .unwrap()
+            .unwrap();
+        repo.save().await.unwrap();
+
+        // Generate id_token
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            "aud": client_id,
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            "iss": "https://example.com/",
+        });
+
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let mut cookie_jar = state.cookie_jar();
+        let info = SessionInfo::from_session(&browser_session);
+        cookie_jar = cookie_jar.update_session_info(&info);
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
+        };
+
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions_with_no_browser_session_in_cookie(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "id_token_signed_response_alg": "RS256",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Create a user
         let mut repo = state.repository().await.unwrap();
         let user = repo
             .user()
@@ -367,11 +525,11 @@ mod tests {
             .unwrap();
         repo.save().await.unwrap();
 
+        // Generate id_token
         let exp = state.clock.now() + Duration::minutes(10);
         let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
             "sub": user.id,
-            // "sid": sid,
             "aud": client_id,
             "exp": exp.timestamp(),
             "iat": iat.timestamp(),
@@ -407,7 +565,204 @@ mod tests {
         let request = Request::get(url).empty();
         let request = cookies.with_cookies(request);
         let response = state.request(request).await;
-        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::SEE_OTHER);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions_with_wrong_issuer_in_id_token(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "id_token_signed_response_alg": "RS256",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Create a user and its browser session
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let browser_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
+            .await
+            .unwrap();
+
+        // Lookup the client in the database and add oauth2 session
+        let client = repo
+            .oauth2_client()
+            .find_by_client_id(&client_id)
+            .await
+            .unwrap()
+            .unwrap();
+        repo.oauth2_session()
+            .add_from_browser_session(
+                &mut state.rng(),
+                &state.clock,
+                &client,
+                &browser_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+        repo.save().await.unwrap();
+
+        // Generate id token
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            "aud": client_id,
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            // Set wrong issuer
+            "iss": "https://wrongissuer.com/",
+        });
+
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let mut cookie_jar = state.cookie_jar();
+        let info = SessionInfo::from_session(&browser_session);
+        cookie_jar = cookie_jar.update_session_info(&info);
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
+        };
+
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions_with_wrong_client_id_in_id_token(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "id_token_signed_response_alg": "RS256",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Create a user and its browser session
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let browser_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
+            .await
+            .unwrap();
+
+        // Lookup the client in the database and add oauth2 session
+        let client = repo
+            .oauth2_client()
+            .find_by_client_id(&client_id)
+            .await
+            .unwrap()
+            .unwrap();
+        repo.oauth2_session()
+            .add_from_browser_session(
+                &mut state.rng(),
+                &state.clock,
+                &client,
+                &browser_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+        repo.save().await.unwrap();
+
+        // Generate id_token
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            // Set wrong client id
+            "aud": "wrong_client_id",
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            "iss": "https://example.com/",
+        });
+
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let mut cookie_jar = state.cookie_jar();
+        let info = SessionInfo::from_session(&browser_session);
+        cookie_jar = cookie_jar.update_session_info(&info);
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
+        };
+
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
         response.assert_status(StatusCode::SEE_OTHER);
     }
 }

--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -13,9 +13,7 @@ use hyper::StatusCode;
 use mas_axum_utils::{SessionInfoExt, cookies::CookieJar, record_error};
 use mas_data_model::{BoxClock, BoxRng};
 use mas_keystore::Keystore;
-use mas_oidc_client::{
-    requests::jose::{JwtVerificationData, verify_signed_jwt},
-};
+use mas_oidc_client::requests::jose::{JwtVerificationData, verify_signed_jwt};
 use mas_router::UrlBuilder;
 use mas_storage::{
     BoxRepository, RepositoryAccess,
@@ -25,11 +23,9 @@ use mas_storage::{
 use oauth2_types::errors::{ClientError, ClientErrorCode};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::info;
 
 use crate::{BoundActivityTracker, impl_from_error_for_route};
-
-use mas_oidc_client::error::JwtVerificationError;
-use tracing::info;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct EndSessionParam {
@@ -41,20 +37,6 @@ pub(crate) struct EndSessionParam {
 pub(crate) enum RouteError {
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[error("bad request")]
-    BadRequest,
-
-    #[error("client not found")]
-    ClientNotFound,
-
-    #[error("client is unauthorized")]
-    UnauthorizedClient,
-
-    // #[error("unsupported token type")]
-    // UnsupportedTokenType,
-    #[error("unknown token")]
-    UnknownToken,
 }
 
 impl_from_error_for_route!(mas_storage::RepositoryError);
@@ -68,44 +50,9 @@ impl IntoResponse for RouteError {
                 Json(ClientError::from(ClientErrorCode::ServerError)),
             )
                 .into_response(),
-
-            Self::BadRequest => (
-                StatusCode::BAD_REQUEST,
-                Json(ClientError::from(ClientErrorCode::InvalidRequest)),
-            )
-                .into_response(),
-
-            Self::ClientNotFound => (
-                StatusCode::UNAUTHORIZED,
-                Json(ClientError::from(ClientErrorCode::InvalidClient)),
-            )
-                .into_response(),
-
-            // Self::ClientNotAllowed |
-            Self::UnauthorizedClient => (
-                StatusCode::UNAUTHORIZED,
-                Json(ClientError::from(ClientErrorCode::UnauthorizedClient)),
-            )
-                .into_response(),
-
-            // Self::UnsupportedTokenType => (
-            //     StatusCode::BAD_REQUEST,
-            //     Json(ClientError::from(ClientErrorCode::UnsupportedTokenType)),
-            // )
-            //     .into_response(),
-
-            // If the token is unknown, we still return a 200 OK response.
-            Self::UnknownToken => StatusCode::OK.into_response(),
         };
 
         (sentry_event_id, response).into_response()
-    }
-}
-
-impl From<JwtVerificationError> for RouteError {
-    fn from(_e: JwtVerificationError) -> Self {
-        info!(%_e);
-        Self::UnknownToken
     }
 }
 
@@ -122,36 +69,49 @@ pub(crate) async fn get(
 ) -> Result<Response, RouteError> {
     let (session_info, cookie_jar) = cookie_jar.session_info();
 
-    let browser_session_id = session_info
-        .current_session_id()
-        .ok_or(RouteError::BadRequest)?;
+    let Some(browser_session_id) = session_info.current_session_id() else {
+        info!("Cannot get browser session id from cookie");
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    };
 
-    let browser_session = repo
-        .browser_session()
-        .lookup(browser_session_id)
-        .await?
-        .ok_or(RouteError::BadRequest)?;
+    let Some(browser_session) = repo.browser_session().lookup(browser_session_id).await? else {
+        info!(
+            "Cannot find browser session[browser session id={}]",
+            browser_session_id
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    };
 
-    info!(%browser_session.id);
-
-    let oauth_session = repo
+    let Some(oauth_session) = repo
         .oauth2_session()
         .find_by_browser_session(browser_session.id)
         .await?
-        .ok_or(RouteError::BadRequest)?;
+    else {
+        info!(
+            "Cannot find oauth2 session[browser session id={}]",
+            browser_session_id
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    };
 
-    info!(%oauth_session.id);
-    info!(%oauth_session.client_id);
-    let client = repo
-        .oauth2_client()
-        .lookup(oauth_session.client_id)
-        .await?
-        .filter(|client| client.id_token_signed_response_alg.is_some())
-        .ok_or(RouteError::ClientNotFound)?;
+    let Some(client) = repo.oauth2_client().lookup(oauth_session.client_id).await? else {
+        info!(
+            "Cannot find client [browser session id={}, oauth2 session id: {}]",
+            browser_session_id, oauth_session.id
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    };
+
+    if client.id_token_signed_response_alg.is_none() {
+        info!(
+            "No Signed ID Token Algorithm is present [browser session id={}, oauth2 session id: {}]",
+            browser_session_id, oauth_session.id
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    }
 
     let jwks = key_store.public_jwks();
     let issuer: String = url_builder.oidc_issuer().into();
-    info!(%issuer);
 
     let id_token_verification_data = JwtVerificationData {
         issuer: Some(&issuer),
@@ -160,15 +120,20 @@ pub(crate) async fn get(
         client_id: &client.client_id,
     };
 
-    info!("id_token_verification_data");
-    verify_signed_jwt(
-        &params.id_token_hint,
-        id_token_verification_data,
-    )?;
+    if let Err(e) = verify_signed_jwt(&params.id_token_hint, id_token_verification_data) {
+        info!(
+            "Cannot verify id_token [browser session id={}, oauth2 session id: {}, id_token={}]: {:?}",
+            browser_session_id, oauth_session.id, params.id_token_hint, e
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+    }
 
     // Check that the session is still valid.
     if !oauth_session.is_valid() {
-        info!("NOT VALID : oauth_session.is_valid");
+        info!(
+            "Invalid oauth session [browser session id={}, oauth2 session id: {}]",
+            browser_session_id, oauth_session.id
+        );
         // If the session is not valid, we redirect to post logout uri
         return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
     }
@@ -176,8 +141,11 @@ pub(crate) async fn get(
     // Check that the client ending the session is the same as the client that
     // created it.
     if client.id != oauth_session.client_id {
-        info!("NOT VALID : client.id != oauth_session.client_id");
-        return Err(RouteError::UnauthorizedClient);
+        info!(
+            "Invalid client id [browser session id={}, oauth2 session id: {}, client id: {}]",
+            browser_session_id, oauth_session.id, client.id
+        );
+        return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
     }
 
     activity_tracker
@@ -187,13 +155,14 @@ pub(crate) async fn get(
     // If the session is associated with a user, make sure we schedule a device
     // deletion job for all the devices associated with the session.
     if let Some(user_id) = oauth_session.user_id {
-        info!(%user_id);
         // Fetch the user
-        let user = repo
-            .user()
-            .lookup(user_id)
-            .await?
-            .ok_or(RouteError::UnknownToken)?;
+        let Some(user) = repo.user().lookup(user_id).await? else {
+            info!(
+                "Cannot find user [browser session id={}, oauth2 session id: {}, user id: {}]",
+                browser_session_id, oauth_session.id, user_id
+            );
+            return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
+        };
 
         // Schedule a job to sync the devices of the user with the homeserver
         repo.queue_job()
@@ -220,27 +189,23 @@ pub(crate) async fn get(
     Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response())
 }
 
-
 #[cfg(test)]
 mod tests {
-    use chrono::{Utc, Duration};
+    use chrono::Duration;
     use hyper::{Request, StatusCode};
-    use mas_axum_utils::SessionInfoExt;
-    use mas_data_model::Session;
-    use mas_data_model::{Clock as _, Device};
-    use sqlx::PgPool;
-    use mas_router::SimpleRoute;
-    use tracing::info;
-
-    use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
-
-    use serde::Serialize;
-    use mas_axum_utils::SessionInfo;
-    use oauth2_types::scope::OPENID;
-    use oauth2_types::scope::Scope;
-    use oauth2_types::registration::ClientRegistrationResponse;
+    use mas_axum_utils::{SessionInfo, SessionInfoExt};
+    use mas_data_model::{Clock as _, Session};
     use mas_iana::jose::JsonWebSignatureAlg;
     use mas_jose::jwt::{JsonWebSignatureHeader, Jwt};
+    use mas_router::SimpleRoute;
+    use oauth2_types::{
+        registration::ClientRegistrationResponse,
+        scope::{OPENID, Scope},
+    };
+    use serde::Serialize;
+    use sqlx::PgPool;
+
+    use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
 
     #[derive(Serialize)]
     struct Query {
@@ -248,10 +213,8 @@ mod tests {
         post_logout_redirect_uri: String,
     }
 
-
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_end_sessions(pool: PgPool) {
-
         setup();
         let state = TestState::from_pool(pool).await.unwrap();
         let mut rng = state.rng();
@@ -275,16 +238,16 @@ mod tests {
         // Provision a provider and a link
         let mut repo = state.repository().await.unwrap();
         let user = repo
-        .user()
-        .add(&mut rng, &state.clock, "alice".to_owned())
-        .await
-        .unwrap();
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
         let browser_session = repo
-                .browser_session()
-                .add(&mut rng, &state.clock, &user, Some("Chrome".to_string()))
-                .await
-                .unwrap();
-        
+            .browser_session()
+            .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
+            .await
+            .unwrap();
+
         // Lookup the client in the database.
         let client = repo
             .oauth2_client()
@@ -292,25 +255,24 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        info!(%client.id);
         let oauth2_session: Session = repo
-        .oauth2_session()
-        .add_from_browser_session(
-            &mut state.rng(),
-            &state.clock,
-            &client,
-            &browser_session,
-            Scope::from_iter([OPENID]),
-        )
-        .await
-        .unwrap();
+            .oauth2_session()
+            .add_from_browser_session(
+                &mut state.rng(),
+                &state.clock,
+                &client,
+                &browser_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
         repo.save().await.unwrap();
 
         // Grab a key to sign the id_token
         // We could generate a key on the fly, but because we have one available here,
         // why not use it?
-        let exp = Utc::now() +  Duration::minutes(10);
-        let iat = Utc::now() -  Duration::minutes(10);
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
             "sub": user.id,
             // "sid": sid,
@@ -320,18 +282,6 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        // {
-//   "iat": 1764689290,
-//   "nonce": "5rODS4YNyb",
-//   "c_hash": "-OmcZ7nYnONkQf4jKquFBQ",
-//   "sub": "01HWCMZ39R7B7E3S7S9G6PXZNK",
-//   "exp": 1764692890,
-//   "aud": "01K6WGWE47QZXKB1M50DSHYN72",
-//   "auth_time": 1764689288,
-//   "at_hash": "76CITZVAFDkMItIwj6VCKQ",
-//   "iss": "https://auth.dev01.tchap.incubateur.net/"
-// }
-        info!(%id_token_hint_claims);
         let key = state
             .key_store
             .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
@@ -341,7 +291,8 @@ mod tests {
             .params()
             .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
             .unwrap();
-        let header: JsonWebSignatureHeader = JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
         let id_token_hint =
             Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
 
@@ -351,21 +302,19 @@ mod tests {
         let cookies = CookieHelper::new();
         cookies.import(cookie_jar);
 
-
         let q = Query {
             id_token_hint: id_token_hint.into_string(),
-            post_logout_redirect_uri: "https://example.com/".to_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
         };
-    
+
         let query = serde_urlencoded::to_string(q).unwrap();
         let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
-        info!("{}", url);
         let request = Request::get(url).empty();
         let request = cookies.with_cookies(request);
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::SEE_OTHER);
-        
+
         // The finished_at timestamp should be the same as the current time
         let mut repo = state.repository().await.unwrap();
         let expected = repo
@@ -381,13 +330,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(expected_oauth2_session.finished_at().unwrap(), state.clock.now());
-
+        assert_eq!(
+            expected_oauth2_session.finished_at().unwrap(),
+            state.clock.now()
+        );
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    async fn test_end_sessions_when_no_browser_session(pool: PgPool) {
-
+    async fn test_end_sessions_with_no_browser_session(pool: PgPool) {
         setup();
         let state = TestState::from_pool(pool).await.unwrap();
         let mut rng = state.rng();
@@ -411,47 +361,14 @@ mod tests {
         // Provision a provider and a link
         let mut repo = state.repository().await.unwrap();
         let user = repo
-        .user()
-        .add(&mut rng, &state.clock, "alice".to_owned())
-        .await
-        .unwrap();
-        
-        let browser_session = repo
-                .compat_session()
-                .add(&mut rng, &state.clock, &user, 
-                    Device::from("AABBCCDDEE".to_owned()),
-                    None,
-                    false,
-                    None)
-                .await
-                .unwrap();
-        
-        // Lookup the client in the database.
-        let client = repo
-            .oauth2_client()
-            .find_by_client_id(&client_id)
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
             .await
-            .unwrap()
             .unwrap();
-        info!(%client.id);
-        // let oauth2_session: Session = repo
-        // .oauth2_session()
-        // .add_from_browser_session(
-        //     &mut state.rng(),
-        //     &state.clock,
-        //     &client,
-        //     &browser_session,
-        //     Scope::from_iter([OPENID]),
-        // )
-        // .await
-        // .unwrap();
         repo.save().await.unwrap();
 
-        // Grab a key to sign the id_token
-        // We could generate a key on the fly, but because we have one available here,
-        // why not use it?
-        let exp = Utc::now() +  Duration::minutes(10);
-        let iat = Utc::now() -  Duration::minutes(10);
+        let exp = state.clock.now() + Duration::minutes(10);
+        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
             "sub": user.id,
             // "sid": sid,
@@ -461,7 +378,6 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        info!(%id_token_hint_claims);
         let key = state
             .key_store
             .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
@@ -471,151 +387,27 @@ mod tests {
             .params()
             .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
             .unwrap();
-        let header: JsonWebSignatureHeader = JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let header: JsonWebSignatureHeader =
+            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
         let id_token_hint =
             Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
 
+        // We will send the cookie with no session id
         let cookie_jar = state.cookie_jar();
-        // cookie_jar = cookie_jar.session_info();
         let cookies = CookieHelper::new();
         cookies.import(cookie_jar);
 
-
         let q = Query {
             id_token_hint: id_token_hint.into_string(),
-            post_logout_redirect_uri: "https://example.com/".to_string(),
+            post_logout_redirect_uri: "https://example.com/".to_owned(),
         };
-    
+
         let query = serde_urlencoded::to_string(q).unwrap();
         let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
-        info!("{}", url);
         let request = Request::get(url).empty();
         let request = cookies.with_cookies(request);
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::SEE_OTHER);
-        
-        // // The finished_at timestamp should be the same as the current time
-        // let mut repo = state.repository().await.unwrap();
-        // let expected = repo
-        //     .browser_session()
-        //     .lookup(browser_session.id)
-        //     .await
-        //     .unwrap()
-        //     .unwrap();
-        // assert_eq!(expected.finished_at.unwrap(), state.clock.now());
-        // let expected_oauth2_session: Session = repo
-        //     .oauth2_session()
-        //     .lookup(oauth2_session.id)
-        //     .await
-        //     .unwrap()
-        //     .unwrap();
-        // assert_eq!(expected_oauth2_session.finished_at().unwrap(), state.clock.now());
-
     }
-
-    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    // async fn test_end_sessions(pool: PgPool) {
-    //     setup();
-    //     let mut state = TestState::from_pool(pool).await.unwrap();
-    //     let token = state.token_with_scope("urn:mas:admin").await;
-    //     let mut rng = state.rng();
-
-    //     // Provision a user and a compat session
-    //     let mut repo = state.repository().await.unwrap();
-    //     let user = repo
-    //         .user()
-    //         .add(&mut rng, &state.clock, "alice".to_owned())
-    //         .await
-    //         .unwrap();
-    //     let device = Device::generate(&mut rng);
-    //     let session = repo
-    //         .compat_session()
-    //         .add(&mut rng, &state.clock, &user, device, None, false, None)
-    //         .await
-    //         .unwrap();
-    //     repo.save().await.unwrap();
-
-    //     let request = Request::get(format!("/oauth2/end_session", &user.id))
-    //         .bearer(&token)
-    //         .empty();
-    //     let response = state.request(request).await;
-    //     response.assert_status(StatusCode::OK);
-    //     let body: serde_json::Value = response.json();
-
-    //     assert_eq!(body["data"]["id"], format!("{}", &user.id));
-    //     // The finished_at timestamp should be the same as the current time
-    //     let mut repo = state.repository().await.unwrap();
-    //     let expected = repo
-    //         .compat_session()
-    //         .lookup(session.id)
-    //         .await
-    //         .unwrap()
-    //         .unwrap();
-    //     assert_eq!(expected.finished_at().unwrap(), state.clock.now());
-    // }
-
-    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    // async fn test_kill_already_finished_session(pool: PgPool) {
-    //     setup();
-    //     let mut state = TestState::from_pool(pool).await.unwrap();
-    //     let token = state.token_with_scope("urn:mas:admin").await;
-    //     let mut rng = state.rng();
-
-    //     // Provision a user and a compat session
-    //     let mut repo = state.repository().await.unwrap();
-    //     let user = repo
-    //         .user()
-    //         .add(&mut rng, &state.clock, "alice".to_owned())
-    //         .await
-    //         .unwrap();
-    //     let device = Device::generate(&mut rng);
-    //     let session = repo
-    //         .compat_session()
-    //         .add(&mut rng, &state.clock, &user, device, None, false, None)
-    //         .await
-    //         .unwrap();
-
-    //     // Finish the session first
-    //     let session = repo
-    //         .compat_session()
-    //         .finish(&state.clock, session)
-    //         .await
-    //         .unwrap();
-
-    //     repo.save().await.unwrap();
-
-    //     // Move the clock forward
-    //     state.clock.advance(Duration::try_minutes(1).unwrap());
-
-    //     let request = Request::post(format!("/api/admin/v1/users/{}/kill-sessions", &user.id))
-    //         .bearer(&token)
-    //         .empty();
-    //     let response = state.request(request).await;
-    //     response.assert_status(StatusCode::OK);
-    //     let body: serde_json::Value = response.json();
-
-    //     assert_eq!(body["data"]["id"], format!("{}", &user.id));
-    //     let mut repo = state.repository().await.unwrap();
-    //     let expected = repo
-    //         .compat_session()
-    //         .lookup(session.id)
-    //         .await
-    //         .unwrap()
-    //         .unwrap();
-    //     assert_ne!(expected.finished_at().unwrap(), state.clock.now());
-    // }
-
-    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    // async fn test_kill_sessions_on_unknown_users(pool: PgPool) {
-    //     setup();
-    //     let mut state = TestState::from_pool(pool).await.unwrap();
-    //     let token = state.token_with_scope("urn:mas:admin").await;
-
-    //     let request = Request::post("/api/admin/v1/users/01040G2081040G2081040G2081/kill-sessions")
-    //         .bearer(&token)
-    //         .empty();
-    //     let response = state.request(request).await;
-    //     response.assert_status(StatusCode::NOT_FOUND);
-    // }
 }

--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -142,10 +142,8 @@ pub(crate) async fn get(
         .record_oauth2_session(&clock, &oauth_session)
         .await;
 
-    // If the session is associated with a user, make sure we schedule a device
-    // deletion job for all the devices associated with the session.
+    // schedule a job which syncs the list of devices of a user with the homeserver
     if let Some(user_id) = oauth_session.user_id {
-        // Fetch the user
         let Some(user) = repo.user().lookup(user_id).await? else {
             info!(
                 "Cannot find user [browser session id={}, oauth2 session id: {}, user id: {}]",
@@ -154,7 +152,6 @@ pub(crate) async fn get(
             return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
         };
 
-        // Schedule a job to sync the devices of the user with the homeserver
         repo.queue_job()
             .schedule_job(&mut rng, &clock, SyncDevicesJob::new(&user))
             .await?;
@@ -181,25 +178,23 @@ pub(crate) async fn get(
 
 #[cfg(test)]
 mod tests {
-    use mas_keystore::Keystore;
-
     use hyper::{Request, StatusCode};
     use mas_axum_utils::{SessionInfo, SessionInfoExt};
     use mas_data_model::{Clock as _, Session};
     use mas_iana::jose::JsonWebSignatureAlg;
     use mas_jose::jwt::{JsonWebSignatureHeader, Jwt};
+    use mas_keystore::Keystore;
     use mas_router::SimpleRoute;
-    use serde_json::Value;
-
     use oauth2_types::{
         registration::ClientRegistrationResponse,
         scope::{OPENID, Scope},
     };
+    use rand_chacha::ChaChaRng;
     use serde::Serialize;
+    use serde_json::Value;
     use sqlx::PgPool;
 
     use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
-    use rand_chacha::ChaChaRng;
 
     #[derive(Serialize)]
     struct Query {
@@ -269,7 +264,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -356,7 +352,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -427,7 +424,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -476,8 +474,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
-
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         // We will send the cookie with no session id
         let cookie_jar = state.cookie_jar();
@@ -558,7 +556,8 @@ mod tests {
             "iss": "https://wrongissuer.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -640,8 +639,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
-
+        let id_token_hint: Jwt<'_, Value> =
+            sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -662,7 +661,8 @@ mod tests {
         response.assert_status(StatusCode::SEE_OTHER);
     }
 
-    // same util function is defined in link.rs, might be good to define it in test_utils.rs
+    // same util function is defined in link.rs, might be good to define it in
+    // test_utils.rs
     pub fn sign_token(
         rng: &mut ChaChaRng,
         keystore: &Keystore,

--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -181,12 +181,16 @@ pub(crate) async fn get(
 
 #[cfg(test)]
 mod tests {
+    use mas_keystore::Keystore;
+
     use hyper::{Request, StatusCode};
     use mas_axum_utils::{SessionInfo, SessionInfoExt};
     use mas_data_model::{Clock as _, Session};
     use mas_iana::jose::JsonWebSignatureAlg;
     use mas_jose::jwt::{JsonWebSignatureHeader, Jwt};
     use mas_router::SimpleRoute;
+    use serde_json::Value;
+
     use oauth2_types::{
         registration::ClientRegistrationResponse,
         scope::{OPENID, Scope},
@@ -195,6 +199,7 @@ mod tests {
     use sqlx::PgPool;
 
     use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
+    use rand_chacha::ChaChaRng;
 
     #[derive(Serialize)]
     struct Query {
@@ -231,6 +236,7 @@ mod tests {
             .add(&mut rng, &state.clock, "alice".to_owned())
             .await
             .unwrap();
+
         let browser_session = repo
             .browser_session()
             .add(&mut rng, &state.clock, &user, Some("Chrome".to_owned()))
@@ -263,19 +269,7 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -362,19 +356,7 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -445,19 +427,7 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -506,19 +476,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
 
         // We will send the cookie with no session id
         let cookie_jar = state.cookie_jar();
@@ -599,19 +558,7 @@ mod tests {
             "iss": "https://wrongissuer.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -693,19 +640,8 @@ mod tests {
             "iss": "https://example.com/",
         });
 
-        let key = state
-            .key_store
-            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
+        let id_token_hint: Jwt<'_, Value> = sign_token(&mut rng, &state.key_store, id_token_hint_claims.clone()).unwrap();
 
-        let signer = key
-            .params()
-            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
-            .unwrap();
-        let header: JsonWebSignatureHeader =
-            JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
-        let id_token_hint =
-            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
 
         let mut cookie_jar = state.cookie_jar();
         let info = SessionInfo::from_session(&browser_session);
@@ -724,5 +660,25 @@ mod tests {
         let request = cookies.with_cookies(request);
         let response = state.request(request).await;
         response.assert_status(StatusCode::SEE_OTHER);
+    }
+
+    // same util function is defined in link.rs, might be good to define it in test_utils.rs
+    pub fn sign_token(
+        rng: &mut ChaChaRng,
+        keystore: &Keystore,
+        payload: Value,
+    ) -> Result<Jwt<'static, Value>, mas_jose::jwt::JwtSignatureError> {
+        let key = keystore
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let header = JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+
+        Jwt::sign_with_rng(rng, header, payload, &signer)
     }
 }

--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -11,11 +11,10 @@ use axum::{
 use axum_extra::extract::Query;
 use hyper::StatusCode;
 use mas_axum_utils::{SessionInfoExt, cookies::CookieJar, record_error};
-use mas_data_model::{BoxClock, BoxRng, Clock};
+use mas_data_model::{BoxClock, BoxRng};
 use mas_keystore::Keystore;
 use mas_oidc_client::{
-    error::IdTokenError,
-    requests::jose::{JwtVerificationData, verify_id_token},
+    requests::jose::{JwtVerificationData, verify_signed_jwt},
 };
 use mas_router::UrlBuilder;
 use mas_storage::{
@@ -28,6 +27,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{BoundActivityTracker, impl_from_error_for_route};
+
+use mas_oidc_client::error::JwtVerificationError;
+use tracing::info;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct EndSessionParam {
@@ -100,8 +102,9 @@ impl IntoResponse for RouteError {
     }
 }
 
-impl From<IdTokenError> for RouteError {
-    fn from(_e: IdTokenError) -> Self {
+impl From<JwtVerificationError> for RouteError {
+    fn from(_e: JwtVerificationError) -> Self {
+        info!(%_e);
         Self::UnknownToken
     }
 }
@@ -129,12 +132,16 @@ pub(crate) async fn get(
         .await?
         .ok_or(RouteError::BadRequest)?;
 
+    info!(%browser_session.id);
+
     let oauth_session = repo
         .oauth2_session()
         .find_by_browser_session(browser_session.id)
         .await?
         .ok_or(RouteError::BadRequest)?;
 
+    info!(%oauth_session.id);
+    info!(%oauth_session.client_id);
     let client = repo
         .oauth2_client()
         .lookup(oauth_session.client_id)
@@ -144,6 +151,7 @@ pub(crate) async fn get(
 
     let jwks = key_store.public_jwks();
     let issuer: String = url_builder.oidc_issuer().into();
+    info!(%issuer);
 
     let id_token_verification_data = JwtVerificationData {
         issuer: Some(&issuer),
@@ -152,15 +160,15 @@ pub(crate) async fn get(
         client_id: &client.client_id,
     };
 
-    verify_id_token(
+    info!("id_token_verification_data");
+    verify_signed_jwt(
         &params.id_token_hint,
         id_token_verification_data,
-        None,
-        clock.now(),
     )?;
 
     // Check that the session is still valid.
     if !oauth_session.is_valid() {
+        info!("NOT VALID : oauth_session.is_valid");
         // If the session is not valid, we redirect to post logout uri
         return Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response());
     }
@@ -168,6 +176,7 @@ pub(crate) async fn get(
     // Check that the client ending the session is the same as the client that
     // created it.
     if client.id != oauth_session.client_id {
+        info!("NOT VALID : client.id != oauth_session.client_id");
         return Err(RouteError::UnauthorizedClient);
     }
 
@@ -178,6 +187,7 @@ pub(crate) async fn get(
     // If the session is associated with a user, make sure we schedule a device
     // deletion job for all the devices associated with the session.
     if let Some(user_id) = oauth_session.user_id {
+        info!(%user_id);
         // Fetch the user
         let user = repo
             .user()
@@ -208,4 +218,404 @@ pub(crate) async fn get(
     let cookie_jar = cookie_jar.update_session_info(&session_info.mark_session_ended());
 
     Ok((cookie_jar, Redirect::to(&params.post_logout_redirect_uri)).into_response())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Utc, Duration};
+    use hyper::{Request, StatusCode};
+    use mas_axum_utils::SessionInfoExt;
+    use mas_data_model::Session;
+    use mas_data_model::{Clock as _, Device};
+    use sqlx::PgPool;
+    use mas_router::SimpleRoute;
+    use tracing::info;
+
+    use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
+
+    use serde::Serialize;
+    use mas_axum_utils::SessionInfo;
+    use oauth2_types::scope::OPENID;
+    use oauth2_types::scope::Scope;
+    use oauth2_types::registration::ClientRegistrationResponse;
+    use mas_iana::jose::JsonWebSignatureAlg;
+    use mas_jose::jwt::{JsonWebSignatureHeader, Jwt};
+
+    #[derive(Serialize)]
+    struct Query {
+        id_token_hint: String,
+        post_logout_redirect_uri: String,
+    }
+
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions(pool: PgPool) {
+
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "id_token_signed_response_alg": "RS256",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Provision a provider and a link
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+        .user()
+        .add(&mut rng, &state.clock, "alice".to_owned())
+        .await
+        .unwrap();
+        let browser_session = repo
+                .browser_session()
+                .add(&mut rng, &state.clock, &user, Some("Chrome".to_string()))
+                .await
+                .unwrap();
+        
+        // Lookup the client in the database.
+        let client = repo
+            .oauth2_client()
+            .find_by_client_id(&client_id)
+            .await
+            .unwrap()
+            .unwrap();
+        info!(%client.id);
+        let oauth2_session: Session = repo
+        .oauth2_session()
+        .add_from_browser_session(
+            &mut state.rng(),
+            &state.clock,
+            &client,
+            &browser_session,
+            Scope::from_iter([OPENID]),
+        )
+        .await
+        .unwrap();
+        repo.save().await.unwrap();
+
+        // Grab a key to sign the id_token
+        // We could generate a key on the fly, but because we have one available here,
+        // why not use it?
+        let exp = Utc::now() +  Duration::minutes(10);
+        let iat = Utc::now() -  Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            // "sid": sid,
+            "aud": client_id,
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            "iss": "https://example.com/",
+        });
+
+        // {
+//   "iat": 1764689290,
+//   "nonce": "5rODS4YNyb",
+//   "c_hash": "-OmcZ7nYnONkQf4jKquFBQ",
+//   "sub": "01HWCMZ39R7B7E3S7S9G6PXZNK",
+//   "exp": 1764692890,
+//   "aud": "01K6WGWE47QZXKB1M50DSHYN72",
+//   "auth_time": 1764689288,
+//   "at_hash": "76CITZVAFDkMItIwj6VCKQ",
+//   "iss": "https://auth.dev01.tchap.incubateur.net/"
+// }
+        info!(%id_token_hint_claims);
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader = JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let mut cookie_jar = state.cookie_jar();
+        let info = SessionInfo::from_session(&browser_session);
+        cookie_jar = cookie_jar.update_session_info(&info);
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_string(),
+        };
+    
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        info!("{}", url);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::SEE_OTHER);
+        
+        // The finished_at timestamp should be the same as the current time
+        let mut repo = state.repository().await.unwrap();
+        let expected = repo
+            .browser_session()
+            .lookup(browser_session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(expected.finished_at.unwrap(), state.clock.now());
+        let expected_oauth2_session: Session = repo
+            .oauth2_session()
+            .lookup(oauth2_session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(expected_oauth2_session.finished_at().unwrap(), state.clock.now());
+
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_end_sessions_when_no_browser_session(pool: PgPool) {
+
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let mut rng = state.rng();
+
+        // Provision a client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "id_token_signed_response_alg": "RS256",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let ClientRegistrationResponse { client_id, .. } = response.json();
+
+        // Provision a provider and a link
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+        .user()
+        .add(&mut rng, &state.clock, "alice".to_owned())
+        .await
+        .unwrap();
+        
+        let browser_session = repo
+                .compat_session()
+                .add(&mut rng, &state.clock, &user, 
+                    Device::from("AABBCCDDEE".to_owned()),
+                    None,
+                    false,
+                    None)
+                .await
+                .unwrap();
+        
+        // Lookup the client in the database.
+        let client = repo
+            .oauth2_client()
+            .find_by_client_id(&client_id)
+            .await
+            .unwrap()
+            .unwrap();
+        info!(%client.id);
+        // let oauth2_session: Session = repo
+        // .oauth2_session()
+        // .add_from_browser_session(
+        //     &mut state.rng(),
+        //     &state.clock,
+        //     &client,
+        //     &browser_session,
+        //     Scope::from_iter([OPENID]),
+        // )
+        // .await
+        // .unwrap();
+        repo.save().await.unwrap();
+
+        // Grab a key to sign the id_token
+        // We could generate a key on the fly, but because we have one available here,
+        // why not use it?
+        let exp = Utc::now() +  Duration::minutes(10);
+        let iat = Utc::now() -  Duration::minutes(10);
+        let id_token_hint_claims = serde_json::json!({
+            "sub": user.id,
+            // "sid": sid,
+            "aud": client_id,
+            "exp": exp.timestamp(),
+            "iat": iat.timestamp(),
+            "iss": "https://example.com/",
+        });
+
+        info!(%id_token_hint_claims);
+        let key = state
+            .key_store
+            .signing_key_for_algorithm(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+
+        let signer = key
+            .params()
+            .signing_key_for_alg(&JsonWebSignatureAlg::Rs256)
+            .unwrap();
+        let header: JsonWebSignatureHeader = JsonWebSignatureHeader::new(JsonWebSignatureAlg::Rs256);
+        let id_token_hint =
+            Jwt::sign_with_rng(&mut rng, header, id_token_hint_claims.clone(), &signer).unwrap();
+
+        let cookie_jar = state.cookie_jar();
+        // cookie_jar = cookie_jar.session_info();
+        let cookies = CookieHelper::new();
+        cookies.import(cookie_jar);
+
+
+        let q = Query {
+            id_token_hint: id_token_hint.into_string(),
+            post_logout_redirect_uri: "https://example.com/".to_string(),
+        };
+    
+        let query = serde_urlencoded::to_string(q).unwrap();
+        let url = format!("{}?{}", mas_router::OAuth2EndSession::PATH, query);
+        info!("{}", url);
+        let request = Request::get(url).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::SEE_OTHER);
+        
+        // // The finished_at timestamp should be the same as the current time
+        // let mut repo = state.repository().await.unwrap();
+        // let expected = repo
+        //     .browser_session()
+        //     .lookup(browser_session.id)
+        //     .await
+        //     .unwrap()
+        //     .unwrap();
+        // assert_eq!(expected.finished_at.unwrap(), state.clock.now());
+        // let expected_oauth2_session: Session = repo
+        //     .oauth2_session()
+        //     .lookup(oauth2_session.id)
+        //     .await
+        //     .unwrap()
+        //     .unwrap();
+        // assert_eq!(expected_oauth2_session.finished_at().unwrap(), state.clock.now());
+
+    }
+
+    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    // async fn test_end_sessions(pool: PgPool) {
+    //     setup();
+    //     let mut state = TestState::from_pool(pool).await.unwrap();
+    //     let token = state.token_with_scope("urn:mas:admin").await;
+    //     let mut rng = state.rng();
+
+    //     // Provision a user and a compat session
+    //     let mut repo = state.repository().await.unwrap();
+    //     let user = repo
+    //         .user()
+    //         .add(&mut rng, &state.clock, "alice".to_owned())
+    //         .await
+    //         .unwrap();
+    //     let device = Device::generate(&mut rng);
+    //     let session = repo
+    //         .compat_session()
+    //         .add(&mut rng, &state.clock, &user, device, None, false, None)
+    //         .await
+    //         .unwrap();
+    //     repo.save().await.unwrap();
+
+    //     let request = Request::get(format!("/oauth2/end_session", &user.id))
+    //         .bearer(&token)
+    //         .empty();
+    //     let response = state.request(request).await;
+    //     response.assert_status(StatusCode::OK);
+    //     let body: serde_json::Value = response.json();
+
+    //     assert_eq!(body["data"]["id"], format!("{}", &user.id));
+    //     // The finished_at timestamp should be the same as the current time
+    //     let mut repo = state.repository().await.unwrap();
+    //     let expected = repo
+    //         .compat_session()
+    //         .lookup(session.id)
+    //         .await
+    //         .unwrap()
+    //         .unwrap();
+    //     assert_eq!(expected.finished_at().unwrap(), state.clock.now());
+    // }
+
+    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    // async fn test_kill_already_finished_session(pool: PgPool) {
+    //     setup();
+    //     let mut state = TestState::from_pool(pool).await.unwrap();
+    //     let token = state.token_with_scope("urn:mas:admin").await;
+    //     let mut rng = state.rng();
+
+    //     // Provision a user and a compat session
+    //     let mut repo = state.repository().await.unwrap();
+    //     let user = repo
+    //         .user()
+    //         .add(&mut rng, &state.clock, "alice".to_owned())
+    //         .await
+    //         .unwrap();
+    //     let device = Device::generate(&mut rng);
+    //     let session = repo
+    //         .compat_session()
+    //         .add(&mut rng, &state.clock, &user, device, None, false, None)
+    //         .await
+    //         .unwrap();
+
+    //     // Finish the session first
+    //     let session = repo
+    //         .compat_session()
+    //         .finish(&state.clock, session)
+    //         .await
+    //         .unwrap();
+
+    //     repo.save().await.unwrap();
+
+    //     // Move the clock forward
+    //     state.clock.advance(Duration::try_minutes(1).unwrap());
+
+    //     let request = Request::post(format!("/api/admin/v1/users/{}/kill-sessions", &user.id))
+    //         .bearer(&token)
+    //         .empty();
+    //     let response = state.request(request).await;
+    //     response.assert_status(StatusCode::OK);
+    //     let body: serde_json::Value = response.json();
+
+    //     assert_eq!(body["data"]["id"], format!("{}", &user.id));
+    //     let mut repo = state.repository().await.unwrap();
+    //     let expected = repo
+    //         .compat_session()
+    //         .lookup(session.id)
+    //         .await
+    //         .unwrap()
+    //         .unwrap();
+    //     assert_ne!(expected.finished_at().unwrap(), state.clock.now());
+    // }
+
+    // #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    // async fn test_kill_sessions_on_unknown_users(pool: PgPool) {
+    //     setup();
+    //     let mut state = TestState::from_pool(pool).await.unwrap();
+    //     let token = state.token_with_scope("urn:mas:admin").await;
+
+    //     let request = Request::post("/api/admin/v1/users/01040G2081040G2081040G2081/kill-sessions")
+    //         .bearer(&token)
+    //         .empty();
+    //     let response = state.request(request).await;
+    //     response.assert_status(StatusCode::NOT_FOUND);
+    // }
 }

--- a/crates/handlers/src/oauth2/end_session.rs
+++ b/crates/handlers/src/oauth2/end_session.rs
@@ -181,7 +181,6 @@ pub(crate) async fn get(
 
 #[cfg(test)]
 mod tests {
-    use chrono::Duration;
     use hyper::{Request, StatusCode};
     use mas_axum_utils::{SessionInfo, SessionInfoExt};
     use mas_data_model::{Clock as _, Session};
@@ -259,13 +258,8 @@ mod tests {
         repo.save().await.unwrap();
 
         // Generate id_token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             "aud": client_id,
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             "iss": "https://example.com/",
         });
 
@@ -363,13 +357,8 @@ mod tests {
         repo.save().await.unwrap();
 
         // Generate id_token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             "aud": client_id,
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             "iss": "https://example.com/",
         });
 
@@ -451,13 +440,8 @@ mod tests {
         repo.save().await.unwrap();
 
         // Generate id_token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             "aud": client_id,
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             "iss": "https://example.com/",
         });
 
@@ -516,23 +500,9 @@ mod tests {
 
         let ClientRegistrationResponse { client_id, .. } = response.json();
 
-        // Create a user
-        let mut repo = state.repository().await.unwrap();
-        let user = repo
-            .user()
-            .add(&mut rng, &state.clock, "alice".to_owned())
-            .await
-            .unwrap();
-        repo.save().await.unwrap();
-
         // Generate id_token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             "aud": client_id,
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             "iss": "https://example.com/",
         });
 
@@ -623,13 +593,8 @@ mod tests {
         repo.save().await.unwrap();
 
         // Generate id token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             "aud": client_id,
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             // Set wrong issuer
             "iss": "https://wrongissuer.com/",
         });
@@ -722,14 +687,9 @@ mod tests {
         repo.save().await.unwrap();
 
         // Generate id_token
-        let exp = state.clock.now() + Duration::minutes(10);
-        let iat = state.clock.now() - Duration::minutes(10);
         let id_token_hint_claims = serde_json::json!({
-            "sub": user.id,
             // Set wrong client id
             "aud": "wrong_client_id",
-            "exp": exp.timestamp(),
-            "iat": iat.timestamp(),
             "iss": "https://example.com/",
         });
 

--- a/crates/storage-pg/.sqlx/query-fcd8b4b9e003d1540357c6bf1ff9c715560d011d4c01112703a9c046170c84f1.json
+++ b/crates/storage-pg/.sqlx/query-fcd8b4b9e003d1540357c6bf1ff9c715560d011d4c01112703a9c046170c84f1.json
@@ -23,7 +23,7 @@
       "Left": []
     },
     "nullable": [
-      true,
+      false,
       true,
       null
     ]


### PR DESCRIPTION
The specs says :
> When an id_token_hint parameter is present, the OP MUST validate that it was the issuer of the ID Token. The OP SHOULD accept ID Tokens when the RP identified by the ID Token's aud claim and/or sid claim has a current session or had a recent session at the OP, even when the exp time has passed. If the ID Token's sid claim does not correspond to the RP's current session or a recent session at the OP, the OP SHOULD treat the logout request as suspect, and MAY decline to act upon it.

**Checks**
- check that cookie browser session is present
- check that browser session exists
- check that oauth2 session exists
- check that oauth2 client has a signed ID token algo is present
- check the id token
  - check the issuer is the same : done
  - check the aud/sid claim has a current or recent session: done 
  - check the sid claim is the same: no sid is present in our scenario

**For any check failure, we still reply with a redirect to do not fail the client when logging out**

**Tests**
- Tests have been added
- E2E Test : https://github.com/tchapgouv/matrix-authentication-service-tchap/pull/22
