### PR TITLE
:TCHAP: register when user email already exists

### DIFF
--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -283,7 +283,7 @@ pub(crate) async fn post(
         } else if repo.user().exists(&form.username).await? {
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
-        } else  
+        } else
         */
         //:tchap:end
         if !homeserver
@@ -607,8 +607,8 @@ mod tests {
 
     /// :tchap:
     /// Test the registration happy path with `oauth2_authorization_grant` and
-    /// `login_hint``. this test is specific to Tchap beacause in the upstream register there is
-    /// no oauth2_authorization_grant in the fixture
+    /// `login_hint``. this test is specific to Tchap beacause in the upstream
+    /// register there is no oauth2_authorization_grant in the fixture
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_with_login_hint(pool: PgPool) {
         setup();
@@ -985,7 +985,7 @@ mod tests {
                 "username": "john",
                 //:tchap:
                 //"email": "john@example.com",
-                "email": "john", 
+                "email": "john",
                 "password": "hunter2",
                 "password_confirm": "hunter2",
                 "accept_terms": "on",

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -283,7 +283,10 @@ pub(crate) async fn post(
         } else if repo.user().exists(&form.username).await? {
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
-        } else if !homeserver
+        } else  
+        */
+        //:tchap:end
+        if !homeserver
             .is_localpart_available(&form.username)
             .await
             .map_err(InternalError::from_anyhow)?
@@ -298,8 +301,6 @@ pub(crate) async fn post(
             // error from the policy, to avoid showing both
             homeserver_denied_username = true;
         }
-        */
-        //:tchap:end
         if form.password.is_empty() {
             state.add_error_on_field(RegisterFormField::Password, FieldError::Required);
         }
@@ -606,7 +607,7 @@ mod tests {
 
     /// :tchap:
     /// Test the registration happy path with `oauth2_authorization_grant` and
-    /// `login_hint``. this test is specific to Tchap, in upstream there is
+    /// `login_hint``. this test is specific to Tchap beacause in the upstream register there is
     /// no oauth2_authorization_grant in the fixture
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_with_login_hint(pool: PgPool) {
@@ -742,6 +743,7 @@ mod tests {
     }
 
     /// Test the registration happy path
+    #[ignore = "use the test test_register_with_login_hint instead"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register(pool: PgPool) {
         setup();
@@ -795,11 +797,7 @@ mod tests {
         // There should be a new registration in the database
         let mut repo = state.repository().await.unwrap();
         let registration = repo.user_registration().lookup(id).await.unwrap().unwrap();
-        //:tchap:
-        //assert_eq!(registration.username, "john".to_owned());
-        let expected_username = "john-example.com";
-        assert_eq!(registration.username, expected_username.to_owned());
-        //:tchap:end
+        assert_eq!(registration.username, "john".to_owned());
         assert!(registration.password.is_some());
 
         let email_authentication = repo
@@ -853,7 +851,7 @@ mod tests {
         assert!(response.body().contains("Password fields don't match"));
     }
 
-    #[ignore = "tchap does not need it because username is generated automatically"]
+    #[ignore = "Tchap does not check username lenght because it is generated from the email"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_username_too_long(pool: PgPool) {
         setup();
@@ -900,7 +898,7 @@ mod tests {
     }
 
     /// When the user already exists in the database, it should give an error
-    #[ignore = "tchap does not need it because username is not a unique identifier in Tchap"]
+    #[ignore = "Tchap does not check user existance by username but by email"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_user_exists(pool: PgPool) {
         setup();
@@ -953,7 +951,6 @@ mod tests {
 
     /// When the username is already reserved on the homeserver, it should give
     /// an error
-    #[ignore = "tchap does not need it because username is not a unique identifier in Tchap"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_user_reserved(pool: PgPool) {
         setup();
@@ -986,7 +983,9 @@ mod tests {
             .form(serde_json::json!({
                 "csrf": csrf_token,
                 "username": "john",
-                "email": "john@example.com",
+                //:tchap:
+                //"email": "john@example.com",
+                "email": "john", 
                 "password": "hunter2",
                 "password_confirm": "hunter2",
                 "accept_terms": "on",

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -227,6 +227,7 @@ pub(crate) async fn post(
             state.add_error_on_form(FormError::Captcha);
         }
 
+        //:tchap:
         if let Some(email) = &email {
             // Note that we don't check here if the email is already taken here, as
             // we don't want to leak the information about other users. Instead, we will
@@ -236,6 +237,10 @@ pub(crate) async fn post(
             } else if Address::from_str(email).is_err() {
                 state.add_error_on_field(RegisterFormField::Email, FieldError::Invalid);
             }
+
+            // TODO
+            // check if email is already taken, in this case, send an email to notify the user
+            // that he/she already has an account
 
             //verify that email address is allowed in this homeserver
             let server_name = homeserver.homeserver();
@@ -270,6 +275,7 @@ pub(crate) async fn post(
             //mutate the username in the form based on the email
             form.username = email_to_mxid_localpart(email);
         }
+        //:tchap: end
 
         let mut homeserver_denied_username = false;
 
@@ -851,7 +857,7 @@ mod tests {
         assert!(response.body().contains("Password fields don't match"));
     }
 
-    #[ignore = "tchap does not need it"]
+    #[ignore = "tchap does not need it because username is generated automatically"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_username_too_long(pool: PgPool) {
         setup();
@@ -898,25 +904,20 @@ mod tests {
     }
 
     /// When the user already exists in the database, it should give an error
-    #[ignore = "tchap does not need it"]
+    #[ignore = "tchap does not need it because username is not a unique identifier in Tchap"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_user_exists(pool: PgPool) {
         setup();
         let state = TestState::from_pool(pool).await.unwrap();
         let mut rng = state.rng();
         let cookies = CookieHelper::new();
-        //:tchap:
-        let email = "john@example.com";
-        let expected_username = "john-example.com";
 
         // Insert a user in the database first
         let mut repo = state.repository().await.unwrap();
         repo.user()
-            //          .add(&mut rng, &state.clock, "john".to_owned())
-            .add(&mut rng, &state.clock, expected_username.to_owned())
+            .add(&mut rng, &state.clock, "john".to_owned())
             .await
             .unwrap();
-        //:tchap:end
         repo.save().await.unwrap();
 
         // Render the registration page and get the CSRF token
@@ -941,10 +942,8 @@ mod tests {
         let request = Request::post(&*mas_router::PasswordRegister::default().path_and_query())
             .form(serde_json::json!({
                 "csrf": csrf_token,
-                //:tchap:
-                "username": "--",
-                "email": email,
-                //:tchap:end
+                "username": "john",
+                "email": "john@example.com",
                 "password": "hunter2",
                 "password_confirm": "hunter2",
                 "accept_terms": "on",
@@ -958,7 +957,7 @@ mod tests {
 
     /// When the username is already reserved on the homeserver, it should give
     /// an error
-    #[ignore = "tchap does not need it"]
+    #[ignore = "tchap does not need it because username is not a unique identifier in Tchap"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_user_reserved(pool: PgPool) {
         setup();
@@ -983,21 +982,14 @@ mod tests {
             .next()
             .unwrap();
 
-        //:tchap:
         // Reserve "john" on the homeserver
-        //state.homeserver_connection.reserve_localpart("john").await;
-        let expected_username = "john-example.com";
-        state
-            .homeserver_connection
-            .reserve_localpart(expected_username)
-            .await;
-        //:tchap:end
+        state.homeserver_connection.reserve_localpart("john").await;
 
         // Submit the registration form
         let request = Request::post(&*mas_router::PasswordRegister::default().path_and_query())
             .form(serde_json::json!({
                 "csrf": csrf_token,
-                "username": "--",//:tchap:
+                "username": "john",
                 "email": "john@example.com",
                 "password": "hunter2",
                 "password_confirm": "hunter2",
@@ -1011,8 +1003,6 @@ mod tests {
     }
 
     /// Test registration without email when email is not required
-    /// /// :tchap: ignore test
-    #[ignore = "tchap does not need it"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_without_email_when_not_required(pool: PgPool) {
         setup();
@@ -1082,8 +1072,6 @@ mod tests {
 
     /// Test registration with valid email when email is not required
     /// (email input is ignored completely when not required)
-    /// :tchap: ignore test
-    #[ignore = "tchap does not need it"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_with_email_when_not_required(pool: PgPool) {
         setup();

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -238,10 +238,6 @@ pub(crate) async fn post(
                 state.add_error_on_field(RegisterFormField::Email, FieldError::Invalid);
             }
 
-            // TODO
-            // check if email is already taken, in this case, send an email to notify the user
-            // that he/she already has an account
-
             //verify that email address is allowed in this homeserver
             let server_name = homeserver.homeserver();
             let email_result = check_email_allowed(email, server_name, &tchap_config).await;

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -98,6 +98,8 @@ pub(crate) async fn get(
         )));
     }
 
+    //:tchap: skip username checks
+    /*
     // Let's perform last minute checks on the registration, especially to avoid
     // race conditions where multiple users register with the same username or email
     // address
@@ -119,6 +121,8 @@ pub(crate) async fn get(
             "Username is not available"
         )));
     }
+    */
+    //:tchap:end
 
     // Check if the registration token is required and was provided
     let registration_token = if site_config.registration_token_required {

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -98,8 +98,9 @@ pub(crate) async fn get(
         )));
     }
 
-    //:tchap: deactivate this username checks because it raises a 500 error which is caught by our WAF
-    //:tchap: furthermore user existance is covered by email checks below
+    //:tchap: deactivate this username checks because it raises a 500 error which is
+    //:tchap: caught by our WAF furthermore user existance is covered by email
+    //:tchap: checks below
     if false {
         //:tchap:end
         // Let's perform last minute checks on the registration, especially to avoid
@@ -114,8 +115,8 @@ pub(crate) async fn get(
             )));
         }
         //:tchap:
-        }
-        //:tchap:end
+    }
+    //:tchap:end
 
     if !homeserver
         .is_localpart_available(&registration.username)

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -98,19 +98,24 @@ pub(crate) async fn get(
         )));
     }
 
-    //:tchap: skip username checks
-    /*
-    // Let's perform last minute checks on the registration, especially to avoid
-    // race conditions where multiple users register with the same username or email
-    // address
+    //:tchap: deactivate this username checks because it raises a 500 error which is caught by our WAF
+    //:tchap: furthermore user existance is covered by email checks below
+    if false {
+        //:tchap:end
+        // Let's perform last minute checks on the registration, especially to avoid
+        // race conditions where multiple users register with the same username or email
+        // address
 
-    if repo.user().exists(&registration.username).await? {
-        // XXX: this could have a better error message, but as this is unlikely to
-        // happen, we're fine with a vague message for now
-        return Err(InternalError::from_anyhow(anyhow::anyhow!(
-            "Username is already taken"
-        )));
-    }
+        if repo.user().exists(&registration.username).await? {
+            // XXX: this could have a better error message, but as this is unlikely to
+            // happen, we're fine with a vague message for now
+            return Err(InternalError::from_anyhow(anyhow::anyhow!(
+                "Username is already taken"
+            )));
+        }
+        //:tchap:
+        }
+        //:tchap:end
 
     if !homeserver
         .is_localpart_available(&registration.username)
@@ -121,8 +126,6 @@ pub(crate) async fn get(
             "Username is not available"
         )));
     }
-    */
-    //:tchap:end
 
     // Check if the registration token is required and was provided
     let registration_token = if site_config.registration_token_required {

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -22,7 +22,7 @@
     },
     "sign_out": "Sign out",
     "@sign_out": {
-      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/consent.html:77:26-46, pages/index.html:63:30-50, pages/policy_violation.html:38:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
+      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/consent.html:77:26-46, pages/index.html:65:30-50, pages/policy_violation.html:38:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
     },
     "skip": "Skip",
     "@skip": {
@@ -36,7 +36,7 @@
   "app": {
     "human_name": "Tchap",
     "@human_name": {
-      "context": "pages/index.html:39:48-67",
+      "context": "pages/index.html:41:48-67",
       "description": "Human readable name of the application"
     },
     "name": "Tchap",
@@ -46,7 +46,7 @@
     },
     "technical_description": "OpenID Connect discovery document: <a class=\"cpd-link\" data-kind=\"primary\" href=\"%(discovery_url)s\">%(discovery_url)s</a>",
     "@technical_description": {
-      "context": "pages/index.html:42:13-72",
+      "context": "pages/index.html:44:13-72",
       "description": "Introduction text displayed on the home page"
     }
   },
@@ -475,13 +475,13 @@
     "navbar": {
       "my_account": "My account",
       "@my_account": {
-        "context": "pages/index.html:56:28-54"
+        "context": "pages/index.html:58:28-54"
       },
       "register": "Create an account",
       "@register": {},
       "signed_in_as": "Signed in as <span class=\"font-semibold\">%(username)s</span>.",
       "@signed_in_as": {
-        "context": "pages/index.html:53:11-79",
+        "context": "pages/index.html:55:11-79",
         "description": "Displayed in the navbar when the user is signed in"
       }
     },


### PR DESCRIPTION
- deactivate username checks 
- do not deactivate is_localpart_available checks


### Before : 
- Error 500 : user already exists

### After : 

<img width="950" height="448" alt="image" src="https://github.com/user-attachments/assets/eadf23d0-8217-4712-a5a3-f6f7ddad0493" />

