### PR TITLE
:TCHAP: customize sso page

### DIFF
--- a/frontend/tchap/css/tchap.css
+++ b/frontend/tchap/css/tchap.css
@@ -267,3 +267,8 @@ footer {
 }
 
 /* end fix footer dark mode */
+
+/* fix header title color for desktop */
+.lasuite-header__service-title {
+  color: #2845c1 !important;
+}

--- a/tchap/resources/templates/pages/consent.html
+++ b/tchap/resources/templates/pages/consent.html
@@ -39,7 +39,6 @@ Please see LICENSE in the repository root for full details.
       {% endif %}
       <p class="text [&>span]:whitespace-nowrap">
         {{ _("mas.consent.client_wants_access", client_name=client_name, redirect_uri=(grant.redirect_uri | simplify_url)) }}
-        {{ _("mas.consent.this_will_allow", client_name=client_name) }}
       </p>
     </div>
   </header>

--- a/tchap/resources/templates/pages/sso.html
+++ b/tchap/resources/templates/pages/sso.html
@@ -1,0 +1,75 @@
+{#
+Copyright 2024, 2025 New Vector Ltd.
+Copyright 2022-2024 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+-#}
+
+{% set consent_page = true %}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <!-- {% set client_name = login.redirect_uri | simplify_url %} -->
+  {% set client_name = "Tchap" %}
+
+  <header class="page-heading">
+    <div class="consent-client-icon generic">
+      {{ icon.web_browser() }}
+    </div>
+
+  <!-- :tchap: -->
+  {% set initial -%}
+    {%- if matrix_user.display_name -%}
+      {{- matrix_user.display_name[0] | upper -}}
+    {%- else -%}
+      {{- matrix_user.mxid[1] | upper -}}
+    {%- endif -%}
+  {%- endset %}
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.consent.heading") }}</h1>
+      <span class="email-box">
+        {{ matrix_user.display_name or current_session.user.username }}
+      </span>
+      <p class="text [&>span]:whitespace-nowrap">
+        {{ _("mas.consent.client_wants_access", client_name=client_name) }}
+        {{ _("mas.consent.this_will_allow", client_name=client_name) }}
+        <!-- :tchap:end -->
+      </p>
+    </div>
+  </header>
+
+
+  <!--
+  :tchap:
+  {% set initial -%}
+    {%- if matrix_user.display_name -%}
+      {{- matrix_user.display_name[0] | upper -}}
+    {%- else -%}
+      {{- matrix_user.mxid[1] | upper -}}
+    {%- endif -%}
+  {%- endset %}
+
+  <section class="flex items-center p-4 gap-4 border border-[var(--cpd-color-gray-400)] rounded-xl">
+    <div class="avatar-placeholder" data-color="{{ matrix_user.mxid | id_color_hash }}">{{ initial }}</div>
+    <div class="flex flex-col">
+      <div class="text-primary cpd-text-body-lg-semibold">{{ matrix_user.display_name or current_session.user.username }}</div>
+    </div>
+  </section>
+  :tchap:end
+-->
+  <section class="flex flex-col gap-6">
+    <form method="POST" class="cpd-form-root">
+      <input type="hidden" name="csrf" value="{{ csrf_token }}" />
+      {{ button.button(text=_("action.continue")) }}
+    </form>
+
+    {% call logout.button(csrf_token=csrf_token, post_logout_action=action) %}
+      <button type="submit" class="cpd-button primary" data-kind="secondary" data-size="lg" type="submit">
+        {{ _("mas.consent.use_another_account") }}
+      </button>
+    {% endcall %}
+  </section>
+{% endblock content %}

--- a/tchap/resources/templates/pages/sso.html
+++ b/tchap/resources/templates/pages/sso.html
@@ -35,7 +35,6 @@ Please see LICENSE files in the repository root for full details.
       </span>
       <p class="text [&>span]:whitespace-nowrap">
         {{ _("mas.consent.client_wants_access", client_name=client_name) }}
-        {{ _("mas.consent.this_will_allow", client_name=client_name) }}
         <!-- :tchap:end -->
       </p>
     </div>

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -10,7 +10,7 @@
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:74:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:50:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:74:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:66:28-48, sso.html:62:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -191,15 +191,15 @@
     "consent": {
       "client_wants_access": "",
       "@client_wants_access": {
-        "context": "pages/consent.html:41:11-122"
+        "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72, sso.html:36:11-122"
       },
       "continue_to": "Continue to <span>%(client_name)s</span>?",
       "@continue_to": {
-        "context": "pages/device_consent.html:29:13-66, pages/sso.html:23:11-64"
+        "context": "pages/device_consent.html:29:13-66"
       },
       "heading": "Connect this new device to your Tchap account",
       "@heading": {
-        "context": "pages/consent.html:30:27-51"
+        "context": "pages/consent.html:30:27-51, pages/sso.html:32:27-51, sso.html:31:27-51"
       },
       "make_sure_you_trust": "",
       "@make_sure_you_trust": {
@@ -211,13 +211,13 @@
       },
       "this_will_allow": "",
       "@this_will_allow": {
-        "context": "pages/consent.html:42:11-68"
+        "context": "pages/consent.html:42:11-68, pages/sso.html:38:11-68, sso.html:37:11-68"
       },
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {},
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/device_consent.html:139:13-49, pages/sso.html:55:11-47"
+        "context": "pages/device_consent.html:139:13-49, pages/sso.html:71:11-47, sso.html:67:11-47"
       },
       "you_may_be_sharing": "",
       "@you_may_be_sharing": {
@@ -426,9 +426,7 @@
     },
     "legacy_consent": {
       "this_will_setup": "",
-      "@this_will_setup": {
-        "context": "pages/sso.html:26:11-109"
-      }
+      "@this_will_setup": {}
     },
     "login": {
       "call_to_register": "Don't have an account yet?",

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -6,11 +6,11 @@
     },
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:81:11-29, pages/device_consent.html:146:13-31, pages/policy_violation.html:44:13-31"
+      "context": "pages/consent.html:80:11-29, pages/device_consent.html:146:13-31, pages/policy_violation.html:44:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:74:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:66:28-48, sso.html:62:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:73:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:65:28-48, sso.html:62:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -22,7 +22,7 @@
     },
     "sign_out": "Sign out",
     "@sign_out": {
-      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/consent.html:77:26-46, pages/index.html:65:30-50, pages/policy_violation.html:38:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
+      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/consent.html:76:26-46, pages/index.html:65:30-50, pages/policy_violation.html:38:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
     },
     "skip": "Skip",
     "@skip": {
@@ -203,7 +203,7 @@
       },
       "make_sure_you_trust": "",
       "@make_sure_you_trust": {
-        "context": "pages/consent.html:54:81-142"
+        "context": "pages/consent.html:53:81-142"
       },
       "scope_list_preface": "",
       "@scope_list_preface": {
@@ -211,17 +211,17 @@
       },
       "this_will_allow": "",
       "@this_will_allow": {
-        "context": "pages/consent.html:42:11-68, pages/sso.html:38:11-68, sso.html:37:11-68"
+        "context": "sso.html:37:11-68"
       },
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {},
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/device_consent.html:139:13-49, pages/sso.html:71:11-47, sso.html:67:11-47"
+        "context": "pages/device_consent.html:139:13-49, pages/sso.html:70:11-47, sso.html:67:11-47"
       },
       "you_may_be_sharing": "",
       "@you_may_be_sharing": {
-        "context": "pages/consent.html:55:7-42"
+        "context": "pages/consent.html:54:7-42"
       }
     },
     "device_card": {


### PR DESCRIPTION
- customize sso.html to look like consent.html
- fix header title color

To reproduce locally, deactivate MAS flow in tchap web with this feature flag : 

```"tchap_mas_flow": {
        "isActive": false,
```

# Before 

<img width="400" alt="IMG_3798" src="https://github.com/user-attachments/assets/d928e7ee-7f98-4a9c-b30a-4185e20a50e4" />


# After

<img width="400"  alt="Capture d’écran 2026-01-12 à 17 46 04" src="https://github.com/user-attachments/assets/df9ca70b-e957-4063-9faf-e8e8d7d971fd" />


