### PR TITLE
Allow Tchap Desktop in policy

### DIFF
--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -44,11 +44,7 @@ secure_url(x) if {
 	url.host == "tauri.localhost"
 }
 
-# :TCHAP: Accept tchap:/ custom scheme
-secure_url(x) if {
-	startswith(x, "tchap:/")
-}
-# :TCHAP: End
+# :TCHAP: end
 
 host_matches_client_uri(_) if {
 	# Do not check we allow host mismatch
@@ -136,6 +132,13 @@ valid_native_redirector(x) if {
 	url.scheme == "http"
 }
 
+# :TCHAP: allow "tchap:/" deep link
+valid_native_redirector(x) if {
+	startswith(x, "tchap:/")
+}
+
+# :TCHAP: end
+
 # Custom schemes should match the client_uri, reverse-dns style
 # e.g. io.element.app:/ matches https://app.element.io/
 valid_native_redirector(x) if {
@@ -158,13 +161,6 @@ valid_redirect_uri(uri) if {
 	secure_url(uri)
 	host_matches_client_uri(uri)
 }
-
-# :TCHAP: valid redirect for Tchap Desktop
-valid_redirect_uri(uri) if {
-	input.client_metadata.application_type == "web"
-	uri == "tchap:/tauri.localhost/"
-}
-# :TCHAP: End
 
 # METADATA
 # entrypoint: true

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -38,7 +38,6 @@ secure_url(x) if {
 	url.host != "[::1]"
 }
 
-
 # :TCHAP: Accept tauri.localhost for Tchap Desktop
 secure_url(x) if {
 	url := parse_uri(x)
@@ -49,6 +48,7 @@ secure_url(x) if {
 secure_url(x) if {
 	startswith(x, "tchap:/")
 }
+
 # :TCHAP: End
 
 host_matches_client_uri(_) if {

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -39,9 +39,7 @@ secure_url(x) if {
 }
 
 # :TCHAP: Accept http://tauri.localhost for Tchap Desktop
-secure_url(url) if {
-	url == "http://tauri.localhost"
-}
+secure_url("http://tauri.localhost")
 
 # :TCHAP: End
 

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -38,6 +38,13 @@ secure_url(x) if {
 	url.host != "[::1]"
 }
 
+# :TCHAP: Accept http://tauri.localhost for Tchap Desktop
+secure_url(url) if {
+	url == "http://tauri.localhost"
+}
+
+# :TCHAP: End
+
 host_matches_client_uri(_) if {
 	# Do not check we allow host mismatch
 	data.client_registration.allow_host_mismatch
@@ -146,6 +153,14 @@ valid_redirect_uri(uri) if {
 	secure_url(uri)
 	host_matches_client_uri(uri)
 }
+
+# :TCHAP: valid redirect for Tchap Desktop
+valid_redirect_uri(uri) if {
+	input.client_metadata.application_type == "web"
+	uri == "tchap:/tauri.localhost/"
+}
+
+# :TCHAP: End
 
 # METADATA
 # entrypoint: true

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -38,9 +38,17 @@ secure_url(x) if {
 	url.host != "[::1]"
 }
 
-# :TCHAP: Accept http://tauri.localhost for Tchap Desktop
-secure_url("http://tauri.localhost")
 
+# :TCHAP: Accept tauri.localhost for Tchap Desktop
+secure_url(x) if {
+	url := parse_uri(x)
+	url.host == "tauri.localhost"
+}
+
+# :TCHAP: Accept tchap:/ custom scheme
+secure_url(x) if {
+	startswith(x, "tchap:/")
+}
 # :TCHAP: End
 
 host_matches_client_uri(_) if {

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -48,14 +48,6 @@ secure_url(x) if {
 secure_url(x) if {
 	startswith(x, "tchap:/")
 }
-
-# :TCHAP: End
-
-# :TCHAP: Accept element:/ custom scheme
-secure_url(x) if {
-	startswith(x, "element:/")
-}
-
 # :TCHAP: End
 
 host_matches_client_uri(_) if {
@@ -172,15 +164,6 @@ valid_redirect_uri(uri) if {
 	input.client_metadata.application_type == "web"
 	uri == "tchap:/tauri.localhost/"
 }
-
-# :TCHAP: End
-
-# :TCHAP: valid redirect for Element Desktop
-valid_redirect_uri(uri) if {
-	input.client_metadata.application_type == "web"
-	uri == "element:/tauri.localhost/"
-}
-
 # :TCHAP: End
 
 # METADATA

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -51,6 +51,13 @@ secure_url(x) if {
 
 # :TCHAP: End
 
+# :TCHAP: Accept element:/ custom scheme
+secure_url(x) if {
+	startswith(x, "element:/")
+}
+
+# :TCHAP: End
+
 host_matches_client_uri(_) if {
 	# Do not check we allow host mismatch
 	data.client_registration.allow_host_mismatch
@@ -164,6 +171,14 @@ valid_redirect_uri(uri) if {
 valid_redirect_uri(uri) if {
 	input.client_metadata.application_type == "web"
 	uri == "tchap:/tauri.localhost/"
+}
+
+# :TCHAP: End
+
+# :TCHAP: valid redirect for Element Desktop
+valid_redirect_uri(uri) if {
+	input.client_metadata.application_type == "web"
+	uri == "element:/tauri.localhost/"
 }
 
 # :TCHAP: End

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -234,12 +234,13 @@ test_web_redirect_uri if {
 		"redirect_uris": ["https://example.com:8443/callback"],
 	}
 
-	# Allow Tchap Desktop
+	# :TCHAP: Allow Tchap Desktop
 	client_registration.allow with input.client_metadata as {
 		"application_type": "web",
 		"client_uri": "https://tauri.localhost/",
 		"redirect_uris": ["tchap:/tauri.localhost/"],
 	}
+	# :TCHAP: End
 }
 
 test_web_redirect_uri_insecure if {

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -237,7 +237,7 @@ test_web_redirect_uri if {
 	# :TCHAP: Allow Tchap Desktop
 	client_registration.allow with input.client_metadata as {
 		"application_type": "web",
-		"client_uri": "https://tauri.localhost/",
+		"client_uri": "http://tauri.localhost/",
 		"redirect_uris": ["tchap:/tauri.localhost/"],
 	}
 	# :TCHAP: End

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -240,6 +240,13 @@ test_web_redirect_uri if {
 		"client_uri": "http://tauri.localhost/",
 		"redirect_uris": ["tchap:/tauri.localhost/"],
 	}
+
+	# :TCHAP: test how Element Desktop is allowed
+	client_registration.allow with input.client_metadata as {
+		"application_type": "native",
+		"client_uri": "https://element.io/",
+		"redirect_uris": ["io.element.desktop:/vector/webapp/"],
+	}
 	# :TCHAP: End
 }
 

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -233,6 +233,13 @@ test_web_redirect_uri if {
 		"client_uri": "https://example.com/",
 		"redirect_uris": ["https://example.com:8443/callback"],
 	}
+
+	# Allow Tchap Desktop
+	client_registration.allow with input.client_metadata as {
+		"application_type": "web",
+		"client_uri": "https://tauri.localhost/",
+		"redirect_uris": ["tchap:/tauri.localhost/"],
+	}
 }
 
 test_web_redirect_uri_insecure if {

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -236,18 +236,10 @@ test_web_redirect_uri if {
 
 	# :TCHAP: Allow Tchap Desktop
 	client_registration.allow with input.client_metadata as {
-		"application_type": "web",
-		"client_uri": "http://tauri.localhost/",
+		"application_type": "native",
+		"client_uri": "https://tauri.localhost/",
 		"redirect_uris": ["tchap:/tauri.localhost/"],
 	}
-
-	# :TCHAP: test how Element Desktop is allowed
-	client_registration.allow with input.client_metadata as {
-		"application_type": "native",
-		"client_uri": "https://element.io/",
-		"redirect_uris": ["io.element.desktop:/vector/webapp/"],
-	}
-	# :TCHAP: End
 }
 
 test_web_redirect_uri_insecure if {

--- a/tchap/conf/config.template.yaml
+++ b/tchap/conf/config.template.yaml
@@ -137,7 +137,7 @@ policy:
       # for api admin calls
       - 01J44RKQYM4G3TNVANTMTDYTX6
     client_registration:
-      allow_insecure_uris: true
+      allow_insecure_uris: false
       allow_host_mismatch: true
 
 account:

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -10,7 +10,7 @@
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:73:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:65:28-48, sso.html:62:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:73:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:65:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -191,7 +191,7 @@
     "consent": {
       "client_wants_access": "",
       "@client_wants_access": {
-        "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72, sso.html:36:11-122"
+        "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72"
       },
       "continue_to": "Continue to <span>%(client_name)s</span>?",
       "@continue_to": {
@@ -199,7 +199,7 @@
       },
       "heading": "Connect this new device to your Tchap account",
       "@heading": {
-        "context": "pages/consent.html:30:27-51, pages/sso.html:32:27-51, sso.html:31:27-51"
+        "context": "pages/consent.html:30:27-51, pages/sso.html:32:27-51"
       },
       "make_sure_you_trust": "",
       "@make_sure_you_trust": {
@@ -210,14 +210,12 @@
         "context": "pages/device_consent.html:104:15-75"
       },
       "this_will_allow": "",
-      "@this_will_allow": {
-        "context": "sso.html:37:11-68"
-      },
+      "@this_will_allow": {},
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {},
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/device_consent.html:139:13-49, pages/sso.html:70:11-47, sso.html:67:11-47"
+        "context": "pages/device_consent.html:139:13-49, pages/sso.html:70:11-47"
       },
       "you_may_be_sharing": "",
       "@you_may_be_sharing": {
@@ -702,6 +700,20 @@
         "@heading": {
           "context": "pages/upstream_oauth2/link_mismatch.html:19:11-57",
           "description": "Page shown when the user tries to link an upstream account that is already linked to another account"
+        }
+      },
+      "login_link": {
+        "action": "",
+        "@action": {
+          "context": "pages/upstream_oauth2/login_link.html:27:28-70"
+        },
+        "description": "",
+        "@description": {
+          "context": "pages/upstream_oauth2/login_link.html:21:7-85"
+        },
+        "heading": "",
+        "@heading": {
+          "context": "pages/upstream_oauth2/login_link.html:17:27-70"
         }
       },
       "register": {


### PR DESCRIPTION
Note that we should be able to accept one "/" according for scheme
according to https://datatracker.ietf.org/doc/html/rfc8252#section-7.1 et https://datatracker.ietf.org/doc/html/rfc3986#section-3.2


### Tchap desktop
```
curl 'https://auth.tchapgouv.com/oauth2/registration' \
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  -H 'origin: http://tauri.localhost' \
  --data-raw '{"client_name":"Tchap","client_uri":"http://tauri.localhost","response_types":["code"],"grant_types":["authorization_code","refresh_token"],"redirect_uris":["tchap:/tauri.localhost/"],"id_token_signed_response_alg":"RS256","token_endpoint_auth_method":"none","application_type":"web"}'
```

Expected response
`{"client_id":"01KEVTA1C7CTC3P376CP9MEN3Z","client_id_issued_at":1768312604,"redirect_uris":["tchap:/tauri.localhost/"],"grant_types":["authorization_code","refresh_token"],"application_type":"web","token_endpoint_auth_method":"none","id_token_signed_response_alg":"RS256","client_name":"Tchap","client_uri":"http://tauri.localhost/"}`


### Element Desktop

`Client registration body="{\"redirect_uris\":[\"io.element.desktop:/vector/webapp/?no_universal_links=true\"],\"response_types\":[\"code\"],\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"application_type\":\"native\",\"token_endpoint_auth_method\":\"none\",\"id_token_signed_response_alg\":\"RS256\",\"client_name\":\"Element\",\"logo_uri\":\"https://app.element.io/vector-icons/1024.png\",\"client_uri\":\"https://element.io/\",\"policy_uri\":\"https://element.io/cookie-policy\",\"tos_uri\":\"https://element.io/privacy\"}"
`