### PR TITLE
:TCHAP: hide proconnect explanation link on login and register page

### DIFF
--- a/tchap/resources/templates/pages/login.html
+++ b/tchap/resources/templates/pages/login.html
@@ -38,6 +38,7 @@ Please see LICENSE in the repository root for full details.
       <button type="button" class="proconnect-button" onclick="window.location.href = '{{ ('/upstream/authorize/' ~ provider.id ~ params) | prefix_url }}'">
           <span class="proconnect-sr-only">S'identifier avec ProConnect</span>
         </button>
+        <!--
         <p>
           <a
           href="https://www.proconnect.gouv.fr/"
@@ -49,6 +50,7 @@ Please see LICENSE in the repository root for full details.
           Qu’est-ce que ProConnect ?
         </a>
       </p>
+      -->
     </div>
   {% endfor %}
   <!-- #tchap# end -->

--- a/tchap/resources/templates/pages/register/index.html
+++ b/tchap/resources/templates/pages/register/index.html
@@ -36,6 +36,7 @@ Please see LICENSE files in the repository root for full details.
         <button class="proconnect-button" onclick="window.location.href = '{{ ('/upstream/authorize/' ~ provider.id ~ params) | prefix_url }}';">
           <span class="proconnect-sr-only">S'identifier avec ProConnect</span>
         </button>
+        <!--
         <p>
           <a
           href="https://www.proconnect.gouv.fr/"
@@ -47,6 +48,7 @@ Please see LICENSE files in the repository root for full details.
           Qu’est-ce que ProConnect ?
         </a>
       </p>
+      -->
     </div>
     {% endfor %}
 


### PR DESCRIPTION
<img width="554" height="772" alt="image" src="https://github.com/user-attachments/assets/e925861b-e8d8-4f71-9125-6d2fa4378384" />
