### PR TITLE
:tchap: (register) do not check username availability in synapse

### DIFF
--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -284,8 +284,7 @@ pub(crate) async fn post(
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
         } else
-        */
-        //:tchap:end
+        
         if !homeserver
             .is_localpart_available(&form.username)
             .await
@@ -296,11 +295,13 @@ pub(crate) async fn post(
                 username = &form.username,
                 "Homeserver denied username provided by user"
             );
-
             // We defer adding the error on the field, until we know whether we had another
             // error from the policy, to avoid showing both
             homeserver_denied_username = true;
         }
+        */
+        //:tchap:end
+
         if form.password.is_empty() {
             state.add_error_on_field(RegisterFormField::Password, FieldError::Required);
         }

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -277,6 +277,7 @@ pub(crate) async fn post(
 
         //:tchap:
         //we skip username error checks because Tchap account allowance relies on email
+        //we do not want to leak information on email existance at this stage
         /*
         if form.username.is_empty() {
             state.add_error_on_field(RegisterFormField::Username, FieldError::Required);
@@ -284,7 +285,6 @@ pub(crate) async fn post(
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
         } else
-        
         if !homeserver
             .is_localpart_available(&form.username)
             .await
@@ -952,6 +952,7 @@ mod tests {
 
     /// When the username is already reserved on the homeserver, it should give
     /// an error
+    #[ignore = "Tchap does not check user existance by username in Synapse"]
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_register_user_reserved(pool: PgPool) {
         setup();

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -21,7 +21,9 @@ use mas_storage::{
     queue::{ProvisionUserJob, QueueJobRepositoryExt as _},
     user::UserEmailFilter,
 };
-use mas_templates::{RegisterStepsEmailInUseContext, TemplateContext as _, Templates};
+use mas_templates::{
+    ErrorContext, RegisterStepsEmailInUseContext, TemplateContext as _, Templates,
+};
 use opentelemetry::metrics::Counter;
 use ulid::Ulid;
 
@@ -49,6 +51,9 @@ pub(crate) async fn get(
     mut repo: BoxRepository,
     activity_tracker: BoundActivityTracker,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
+    //:tchap:
+    PreferredLanguage(locale): PreferredLanguage,
+    //:tchap:
     State(url_builder): State<UrlBuilder>,
     State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(templates): State<Templates>,
@@ -105,7 +110,6 @@ pub(crate) async fn get(
         // Let's perform last minute checks on the registration, especially to avoid
         // race conditions where multiple users register with the same username or email
         // address
-
         if repo.user().exists(&registration.username).await? {
             // XXX: this could have a better error message, but as this is unlikely to
             // happen, we're fine with a vague message for now
@@ -125,6 +129,26 @@ pub(crate) async fn get(
         }
     }
     //this block is deactivated
+    //:tchap:end
+
+    //:tchap:
+    //if account exists but is deactivated, show an error screen so that users
+    // contact support
+    if let Some(found_user) = repo.user().find_by_username(&registration.username).await?
+        && found_user.deactivated_at.is_some()
+    {
+        let ctx = ErrorContext::new()
+            .with_code("Compte desactivé")
+            .with_description(format!(
+                r"Votre compte existe déjà mais il a été desactivé. 
+                Veuillez contacter le support Tchap: support@tchap.beta.gouv.fr.
+                username:{}",
+                found_user.username
+            ))
+            .with_language(&locale);
+
+        return Ok(Html(templates.render_error(&ctx)?).into_response());
+    }
     //:tchap:end
 
     // Check if the registration token is required and was provided

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -102,7 +102,6 @@ pub(crate) async fn get(
     //:tchap: caught by our WAF furthermore user existance is covered by email
     //:tchap: checks below
     if false {
-        //:tchap:end
         // Let's perform last minute checks on the registration, especially to avoid
         // race conditions where multiple users register with the same username or email
         // address
@@ -114,19 +113,19 @@ pub(crate) async fn get(
                 "Username is already taken"
             )));
         }
-        //:tchap:
-    }
-    //:tchap:end
 
-    if !homeserver
-        .is_localpart_available(&registration.username)
-        .await
-        .map_err(InternalError::from_anyhow)?
-    {
-        return Err(InternalError::from_anyhow(anyhow::anyhow!(
-            "Username is not available"
-        )));
+        if !homeserver
+            .is_localpart_available(&registration.username)
+            .await
+            .map_err(InternalError::from_anyhow)?
+        {
+            return Err(InternalError::from_anyhow(anyhow::anyhow!(
+                "Username is not available"
+            )));
+        }
     }
+    //this block is deactivated
+    //:tchap:end
 
     // Check if the registration token is required and was provided
     let registration_token = if site_config.registration_token_required {

--- a/tchap/conf/config.template.yaml
+++ b/tchap/conf/config.template.yaml
@@ -306,3 +306,11 @@ rate_limiting:
   registration:
     burst: 50000 #insanely high limit for E2E tests
     per_second: 1000 #insanely high limit for E2E tests
+
+  # Limits how many email verification attempts are allowed,
+  email_authentication:
+
+    # based on source IP address.
+    per_ip:
+      burst: 50000 #insanely high limit for E2E tests
+      per_second: 1000 #insanely high limit for E2E tests

--- a/tchap/conf/config.template.yaml
+++ b/tchap/conf/config.template.yaml
@@ -304,5 +304,5 @@ rate_limiting:
   # based on source IP address.
   # This limit can protect against e-mail spam and against people registering too many accounts.
   registration:
-    burst: 500
-    per_second: 0.05
+    burst: 50000 #insanely high limit for E2E tests
+    per_second: 1000 #insanely high limit for E2E tests

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -10,11 +10,11 @@
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:73:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:92:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:65:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:73:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:94:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:61:26-46, pages/register/steps/display_name.html:45:28-48, pages/register/steps/email_in_use.html:28:32-52, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:65:28-48, sso.html:62:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
-      "context": "pages/login.html:103:33-59, pages/register/index.html:20:29-55, pages/upstream_oauth2/do_register.html:197:26-52"
+      "context": "pages/login.html:105:33-59, pages/register/index.html:20:29-55, pages/upstream_oauth2/do_register.html:197:26-52"
     },
     "sign_in": "Sign in",
     "@sign_in": {
@@ -93,7 +93,7 @@
     },
     "password": "Password",
     "@password": {
-      "context": "pages/login.html:80:37-57, pages/reauth.html:28:35-55, pages/register/password.html:53:35-55"
+      "context": "pages/login.html:82:37-57, pages/reauth.html:28:35-55, pages/register/password.html:53:35-55"
     },
     "password_confirm": "Confirm password",
     "@password_confirm": {
@@ -101,7 +101,7 @@
     },
     "username": "Username",
     "@username": {
-      "context": "pages/login.html:74:37-57, pages/register/index.html:59:35-55, pages/register/password.html:38:45-65, pages/upstream_oauth2/do_register.html:104:35-55, pages/upstream_oauth2/do_register.html:109:39-59"
+      "context": "pages/login.html:76:37-57, pages/register/index.html:61:35-55, pages/register/password.html:38:45-65, pages/upstream_oauth2/do_register.html:104:35-55, pages/upstream_oauth2/do_register.html:109:39-59"
     }
   },
   "error": {
@@ -191,7 +191,7 @@
     "consent": {
       "client_wants_access": "",
       "@client_wants_access": {
-        "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72"
+        "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72, sso.html:36:11-122"
       },
       "continue_to": "Continue to <span>%(client_name)s</span>?",
       "@continue_to": {
@@ -199,7 +199,7 @@
       },
       "heading": "Connect this new device to your Tchap account",
       "@heading": {
-        "context": "pages/consent.html:30:27-51, pages/sso.html:32:27-51"
+        "context": "pages/consent.html:30:27-51, pages/sso.html:32:27-51, sso.html:31:27-51"
       },
       "make_sure_you_trust": "",
       "@make_sure_you_trust": {
@@ -210,12 +210,14 @@
         "context": "pages/device_consent.html:104:15-75"
       },
       "this_will_allow": "",
-      "@this_will_allow": {},
+      "@this_will_allow": {
+        "context": "sso.html:37:11-68"
+      },
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {},
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/device_consent.html:139:13-49, pages/sso.html:70:11-47"
+        "context": "pages/device_consent.html:139:13-49, pages/sso.html:70:11-47, sso.html:67:11-47"
       },
       "you_may_be_sharing": "",
       "@you_may_be_sharing": {
@@ -429,11 +431,11 @@
     "login": {
       "call_to_register": "Don't have an account yet?",
       "@call_to_register": {
-        "context": "pages/login.html:99:13-44"
+        "context": "pages/login.html:101:13-44"
       },
       "continue_with_provider": "Continue with %(provider)s",
       "@continue_with_provider": {
-        "context": "pages/register/index.html:82:23-75",
+        "context": "pages/register/index.html:84:23-75",
         "description": "Button to log in with an upstream provider"
       },
       "description": "Please sign in to continue:",
@@ -442,7 +444,7 @@
       },
       "forgot_password": "Forgot password?",
       "@forgot_password": {
-        "context": "pages/login.html:85:35-65",
+        "context": "pages/login.html:87:35-65",
         "description": "On the login page, link to the account recovery process"
       },
       "headline": "Sign in",
@@ -461,11 +463,11 @@
       },
       "no_login_methods": "No login methods available.",
       "@no_login_methods": {
-        "context": "pages/login.html:109:11-42"
+        "context": "pages/login.html:111:11-42"
       },
       "username_or_email": "Username or Email",
       "@username_or_email": {
-        "context": "pages/login.html:70:37-69"
+        "context": "pages/login.html:72:37-69"
       }
     },
     "navbar": {
@@ -620,12 +622,12 @@
     "register": {
       "call_to_login": "Already have an account?",
       "@call_to_login": {
-        "context": "pages/register/index.html:89:35-66, pages/register/password.html:64:33-64",
+        "context": "pages/register/index.html:91:35-66, pages/register/password.html:64:33-64",
         "description": "Displayed on the registration page to suggest to log in instead"
       },
       "continue_with_email": "Continue with my email address",
       "@continue_with_email": {
-        "context": "pages/register/index.html:73:30-67"
+        "context": "pages/register/index.html:75:30-67"
       },
       "continue_with_password": "Continue with password",
       "@continue_with_password": {},
@@ -704,17 +706,11 @@
       },
       "login_link": {
         "action": "",
-        "@action": {
-          "context": "pages/upstream_oauth2/login_link.html:27:28-70"
-        },
+        "@action": {},
         "description": "",
-        "@description": {
-          "context": "pages/upstream_oauth2/login_link.html:21:7-85"
-        },
+        "@description": {},
         "heading": "",
-        "@heading": {
-          "context": "pages/upstream_oauth2/login_link.html:17:27-70"
-        }
+        "@heading": {}
       },
       "register": {
         "choose_username": {

--- a/tchap/resources/translations/fr.json
+++ b/tchap/resources/translations/fr.json
@@ -35,7 +35,7 @@
     "username": "Nom d’utilisateur"
   },
   "error": {
-    "unexpected": "Erreur inattendue"
+    "unexpected": "Une erreur est survenue"
   },
   "mas": {
     "account": {


### PR DESCRIPTION
Problem : when users already have an account, they receive this error 500 :  "Username is not available"

when user creates an account with email/password, a username is created from his/her email with the following rules : 
`address.replace('@', "-").to_lowercase();` [here](https://github.com/tchapgouv/matrix-authentication-service/blob/4d57cb6104f5450cc545169bbc69aafe63ec21c8/crates/tchap/src/lib.rs#L95-L96)

Then we do not want to advertise users that the user exists directly in the register form, it would be a critical hint that the email address exists. 

Instead, we bypass username availability checks in the form so that users are informed of the existance of the account after the email verification.

Username availability is checked in further steps, like in the /finish endpoint

# when user exists
<img width="400" alt="chromium_06-_finish" src="https://github.com/user-attachments/assets/a139c553-e3a2-4147-b745-5d16bd1a0e93" />


# when user exists but is deactivated

<img width="400" alt="chromium_05-_finish" src="https://github.com/user-attachments/assets/518e6852-4ab7-4736-8d39-8e108b7ca20d" />





