### PR TITLE
:tchap: fix windows desktop client uri policy

### DIFF
--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -45,6 +45,12 @@ secure_url(x) if {
 	url.host == "localhost"
 }
 
+# :TCHAP: Accept client url for Tchap Desktop Windows
+secure_url(x) if {
+	url := parse_uri(x)
+	url.scheme == "http"
+	url.host == "tauri.localhost"
+}
 # :TCHAP: end
 
 host_matches_client_uri(_) if {

--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -51,6 +51,7 @@ secure_url(x) if {
 	url.scheme == "http"
 	url.host == "tauri.localhost"
 }
+
 # :TCHAP: end
 
 host_matches_client_uri(_) if {

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -237,7 +237,7 @@ test_web_redirect_uri if {
 	# :TCHAP: Allow Tchap Desktop for Windows
 	client_registration.allow with input.client_metadata as {
 		"application_type": "native",
-		"client_uri": "https://tauri.localhost/",
+		"client_uri": "http://tauri.localhost/",
 		"redirect_uris": ["tchap:/tauri.localhost/"],
 	}
 


### PR DESCRIPTION
client uri sheme is ‘http‘ not ‘https‘