### PR TITLE
:tchap: update cookie samesite for bnum

### DIFF
--- a/crates/axum-utils/src/cookies.rs
+++ b/crates/axum-utils/src/cookies.rs
@@ -99,7 +99,11 @@ impl CookieOption {
         cookie.set_http_only(true);
         cookie.set_secure(self.secure());
         cookie.set_path(self.path().to_owned());
-        cookie.set_same_site(SameSite::Lax);
+        //:tchap:
+        //Control must be done in frame ancestor header
+        //cookie.set_same_site(SameSite::Lax);
+        //:tchap end
+        cookie.set_same_site(SameSite::None);
         cookie
     }
 }


### PR DESCRIPTION
CSRF cookie are not shared with ancestor iframe because of samesite 'Lax' policy

Change cookie policy to allow iframing. (required for MTE - BNUM)
