### PR TITLE
:tchap: silently reactivate account when deactivated on oidc login and password register

### DIFF
--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -332,12 +332,52 @@ pub(crate) async fn get(
 
         (None, Some(user_id)) => {
             // Session linked, but user not logged in: do the login
-            let user = repo
+            let mut user = repo
                 .user()
                 .lookup(user_id)
                 .await?
                 .ok_or(RouteError::UserNotFound(user_id))?;
 
+            //:tchap
+            //reactivate user if deactivated
+            if user.deactivated_at.is_some() {
+                homeserver
+                    .reactivate_user(&user.username)
+                    .await
+                    .map_err(|err| {
+                        tracing::error!(
+                            user.id = %user.id,
+                            "Failed to reactivate user on homeserver, aborting reactivation"
+                        );
+                        RouteError::HomeserverConnection(err)
+                    })?;
+
+                user = repo.user().reactivate(user).await?;
+
+                let env = environment();
+                let provider = repo
+                    .upstream_oauth_provider()
+                    .lookup(link.provider_id)
+                    .await?
+                    .ok_or(RouteError::ProviderNotFound(link.provider_id))?;
+
+                let maybe_email =
+                    extract_email_from_oauth_session(&env, &upstream_session, &provider)?;
+
+                if let Some(email) = maybe_email {
+                    let existing_email = repo.user_email().find(&user, &email).await?;
+                    if existing_email.is_none() {
+                        tracing::info!(
+                            user.id = %user.id,
+                            "Restoring email in a previously deactivated account"
+                        );
+                        repo.user_email()
+                            .add(&mut rng, &clock, &user, email)
+                            .await?;
+                    }
+                }
+            }
+            /*
             // Check that the user is not locked or deactivated
             if user.deactivated_at.is_some() {
                 // The account is deactivated, show the 'account deactivated' fallback
@@ -347,6 +387,8 @@ pub(crate) async fn get(
                 let fallback = templates.render_account_deactivated(&ctx)?;
                 return Ok((cookie_jar, Html(fallback).into_response()));
             }
+            */
+            //:tchap:end
 
             if user.locked_at.is_some() {
                 // The account is locked, show the 'account locked' fallback
@@ -1422,6 +1464,49 @@ async fn validate_email_for_server(
         }
     }
 }
+
+/// Extracts an email from an OAuth upstream session
+///
+/// # Returns
+/// - Ok(Some(email)) - Email was successfully extracted
+/// - Ok(None) - No email could be extracted but it wasn't required
+/// - Err(_) - An error occurred during extraction (e.g., template rendering
+///   failed)
+fn extract_email_from_oauth_session(
+    env: &Environment,
+    upstream_session: &UpstreamOAuthAuthorizationSession,
+    provider: &mas_data_model::UpstreamOAuthProvider,
+) -> Result<Option<String>, RouteError> {
+    let id_token = upstream_session.id_token().map(Jwt::try_from).transpose()?;
+
+    let mut context = AttributeMappingContext::new();
+    if let Some(id_token) = id_token {
+        let (_, payload) = id_token.into_parts();
+        context = context.with_id_token_claims(payload);
+    }
+    if let Some(extra_callback_parameters) = upstream_session.extra_callback_parameters() {
+        context = context.with_extra_callback_parameters(extra_callback_parameters.clone());
+    }
+    if let Some(userinfo) = upstream_session.userinfo() {
+        context = context.with_userinfo_claims(userinfo.clone());
+    }
+    let context = context.build();
+
+    let template = provider
+        .claims_imports
+        .email
+        .template
+        .as_deref()
+        .unwrap_or(DEFAULT_EMAIL_TEMPLATE);
+
+    render_attribute_template(
+        env,
+        template,
+        &context,
+        provider.claims_imports.email.is_required(),
+    )
+}
+
 //:tchap: end
 
 //:tchap:

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -552,42 +552,51 @@ pub(crate) async fn get(
 
                 //let maybe_existing_user = repo.user().find_by_username(&localpart).await?;
 
-                //search user by email instead of username
-                let maybe_existing_user =
-                    tchap::search_user_by_email(&mut repo, &maybe_email.unwrap(), &tchap_config)
-                        .await?;
+                //search user by email first
+                let email = maybe_email.unwrap();
+                let mut maybe_existing_user =
+                    tchap::search_user_by_email(&mut repo, &email, &tchap_config).await?;
 
-                // if user was not found by email but searching by username match, we have a
-                // conflict on the email in Tchap
+                // if user was not found by email, search by username
                 if maybe_existing_user.is_none() {
-                    let maybe_existing_user = repo.user().find_by_username(&localpart).await?;
+                    maybe_existing_user = repo.user().find_by_username(&localpart).await?;
 
-                    if let Some(existing_user) = maybe_existing_user {
+                    if let Some(existing_user) = &maybe_existing_user {
                         let email = &repo
                             .user_email()
-                            .all(&existing_user)
+                            .all(existing_user)
                             .await?
                             .first()
                             .map(|user_email| user_email.email.clone());
 
-                        let ctx = ErrorContext::new()
-                            .with_code("Invalid Data")
-                            .with_description(format!(
-                                r"Un compte Tchap existe mais l'email associé diffère de votre email Proconnect. 
-                                Veuillez contacter le support Tchap: support@tchap.numerique.gouv.fr. 
-                                email_tchap:{email:?}, proconnect_username:{localpart}"
-                            ))
-                            .with_language(&locale);
+                        if email.is_some() {
+                            tracing::warn!(
+                                upstream_oauth_provider.id = %provider.id,
+                                upstream_oauth_link.id = %link.id,
+                                user.id = %existing_user.id,
+                                "Un compte Tchap existe mais l'email associé diffère de l'email Proconnect, email_tchap:{email:?}, proconnect_username:{localpart}");
 
-                        return Ok((
-                            cookie_jar,
-                            Html(templates.render_error(&ctx)?).into_response(),
-                        ));
+                            //if email is not None, there is a conflict between the username and
+                            // the email we know and the ones from proconnect
+                            let ctx = ErrorContext::new()
+                                .with_code("Invalid Data")
+                                .with_description(format!(
+                                    r"Un compte Tchap existe mais l'email associé diffère de votre email Proconnect. 
+                                    Veuillez contacter le support Tchap: support@tchap.numerique.gouv.fr. 
+                                    email_tchap:{email:?}, proconnect_username:{localpart}"
+                                ))
+                                .with_language(&locale);
+
+                            return Ok((
+                                cookie_jar,
+                                Html(templates.render_error(&ctx)?).into_response(),
+                            ));
+                        }
                     }
                 }
                 //:tchap: end
 
-                if let Some(existing_user) = maybe_existing_user {
+                if let Some(mut existing_user) = maybe_existing_user {
                     if !forced_or_required {
                         tracing::warn!(
                             upstream_oauth_provider.id = %provider.id,
@@ -731,6 +740,34 @@ pub(crate) async fn get(
 
                     // Now that we've resolved the conflict, log in that existing user
 
+                    //:tchap:
+                    // we want to reactivate the account
+                    // we want to set the email because it might have been deleted when deactivating
+                    if existing_user.deactivated_at.is_some() {
+                        tracing::info!(
+                            user.id = %existing_user.id,
+                            "Existing account was deactivated, reactivate it"
+                        );
+
+                        // Call the homeserver synchronously to reactivate the user
+                        let _ = homeserver.reactivate_user(&existing_user.username).await;
+
+                        // Now reactivate the user in our database
+                        existing_user = repo.user().reactivate(existing_user).await?;
+
+                        // Add email if not existing
+                        let existing_email = repo.user_email().find(&existing_user, &email).await?;
+                        if existing_email.is_none() {
+                            tracing::info!(
+                                user.id = %existing_user.id,
+                                "Restore email in a previously deactivated account"
+                            );
+                            repo.user_email()
+                                .add(&mut rng, &clock, &existing_user, email)
+                                .await?;
+                        }
+                    }
+                    /*
                     // Check that the user is not locked or deactivated
                     if existing_user.deactivated_at.is_some() {
                         // The account is deactivated, show the 'account deactivated' fallback
@@ -740,6 +777,8 @@ pub(crate) async fn get(
                         let fallback = templates.render_account_deactivated(&ctx)?;
                         return Ok((cookie_jar, Html(fallback).into_response()));
                     }
+                    :tchap: end
+                    */
 
                     if existing_user.locked_at.is_some() {
                         // The account is locked, show the 'account locked' fallback
@@ -3051,12 +3090,17 @@ mod tests {
         let cookie_jar = upstream_sessions.save(cookie_jar, &state.clock);
         cookies.import(cookie_jar);
 
-        //create use with no email
-        let _user = repo
+        //create use with different email
+        let user = repo
             .user()
             .add(&mut rng, &state.clock, existing_username.to_owned())
             .await
             .unwrap();
+        
+        let _user_email = repo
+            .user_email()
+            .add(&mut rng, &state.clock, &user, "any_other@example.com".to_owned())
+            .await;
 
         repo.save().await.unwrap();
 

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -3096,10 +3096,15 @@ mod tests {
             .add(&mut rng, &state.clock, existing_username.to_owned())
             .await
             .unwrap();
-        
+
         let _user_email = repo
             .user_email()
-            .add(&mut rng, &state.clock, &user, "any_other@example.com".to_owned())
+            .add(
+                &mut rng,
+                &state.clock,
+                &user,
+                "any_other@example.com".to_owned(),
+            )
             .await;
 
         repo.save().await.unwrap();

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -21,9 +21,7 @@ use mas_storage::{
     queue::{ProvisionUserJob, QueueJobRepositoryExt as _},
     user::UserEmailFilter,
 };
-use mas_templates::{
-    ErrorContext, RegisterStepsEmailInUseContext, TemplateContext as _, Templates,
-};
+use mas_templates::{RegisterStepsEmailInUseContext, TemplateContext as _, Templates};
 use opentelemetry::metrics::Counter;
 use ulid::Ulid;
 
@@ -51,9 +49,6 @@ pub(crate) async fn get(
     mut repo: BoxRepository,
     activity_tracker: BoundActivityTracker,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
-    //:tchap:
-    PreferredLanguage(locale): PreferredLanguage,
-    //:tchap:
     State(url_builder): State<UrlBuilder>,
     State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(templates): State<Templates>,
@@ -131,26 +126,6 @@ pub(crate) async fn get(
     //this block is deactivated
     //:tchap:end
 
-    //:tchap:
-    //if account exists but is deactivated, show an error screen so that users
-    // contact support
-    if let Some(found_user) = repo.user().find_by_username(&registration.username).await?
-        && found_user.deactivated_at.is_some()
-    {
-        let ctx = ErrorContext::new()
-            .with_code("Compte desactivé")
-            .with_description(format!(
-                r"Votre compte existe déjà mais il a été desactivé. 
-                Veuillez contacter le support Tchap: support@tchap.numerique.gouv.fr.
-                username:{}",
-                found_user.username
-            ))
-            .with_language(&locale);
-
-        return Ok(Html(templates.render_error(&ctx)?).into_response());
-    }
-    //:tchap:end
-
     // Check if the registration token is required and was provided
     let registration_token = if site_config.registration_token_required {
         if let Some(registration_token_id) = registration.user_registration_token_id {
@@ -181,6 +156,9 @@ pub(crate) async fn get(
     } else {
         None
     };
+    //:tchap:
+    let existing_user = repo.user().find_by_username(&registration.username).await?;
+    //:tchap:end
 
     // If there is an email authentication, we need to check that the email
     // address was verified. If there is no email authentication attached, we
@@ -227,6 +205,23 @@ pub(crate) async fn get(
                 )
                     .into_response());
             }
+            //:tchap:
+            // Reactivate user if needed
+            if let Some(ref user) = existing_user
+                && user.deactivated_at.is_some()
+            {
+                tracing::info!(
+                    user.id = %user.id,
+                    "Existing account was deactivated, reactivate it"
+                );
+
+                // Call the homeserver synchronously to reactivate the user
+                let _ = homeserver.reactivate_user(&user.username).await;
+
+                // Now reactivate the user in our database
+                repo.user().reactivate(user.clone()).await?;
+            }
+            //:tchap:end
 
             Some(email_authentication)
         } else {
@@ -300,11 +295,23 @@ pub(crate) async fn get(
         .consume_session(&registration)?
         .save(cookie_jar, &clock);
 
+    /* :tchap: create user only if needed
     // Now we can start the user creation
     let user = repo
         .user()
         .add(&mut rng, &clock, registration.username)
         .await?;
+    */
+
+    let user = if let Some(user) = existing_user {
+        user
+    } else {
+        repo.user()
+            .add(&mut rng, &clock, registration.username)
+            .await?
+    };
+    //:tchap: end
+
     // Also create a browser session which will log the user in
     let user_session = repo
         .browser_session()

--- a/tchap/conf/config.template.yaml
+++ b/tchap/conf/config.template.yaml
@@ -32,7 +32,7 @@ http:
   #  public_base: http://[::]:8080/
   #  issuer: http://[::]:8080/
   public_base: https://auth.tchapgouv.com/
-  issuer: https://auth.tchapgouv.com/
+  issuer: https://tchapgouv.com/
 database:
   uri: postgresql://postgres:postgres@localhost:5439/postgres
   max_connections: 10
@@ -102,6 +102,9 @@ secrets:
         oUQDQgAEMHcshHVFbMSEyyt3ptIdAhnrg+XlQskZ33hZvdtzm6I0wW8H8zslMp+I
         t0KYCeIQ7HTPtgJAOsKxEPBfmVXZmA==
         -----END EC PRIVATE KEY-----
+
+
+
 passwords:
   enabled: true
   schemes:


### PR DESCRIPTION
Before : 

1 - As a deactivated user (by email account validity module most probably), when I connect via proconnect I get this error : 

"Invalid Data"

2 - As a deactivated user (by email account validity module most probably), when I create an account, I get this error : 

"Deactivated account"


After : 
1 - account is reactivated silently 
2 - account is reactivated silently

Details :

As a result of account deactivation, the user `email` is deleted, then account matching of deactivated acounts can be done only by `username`.

Deleting `email` on account deactivation should be removed on another PR

E2E tests : https://github.com/tchapgouv/matrix-authentication-service-tchap/pull/35

