### PR TITLE
Revert "change support email with numerique.gouv"

### DIFF
--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -574,7 +574,7 @@ pub(crate) async fn get(
                             .with_code("Invalid Data")
                             .with_description(format!(
                                 r"Un compte Tchap existe mais l'email associé diffère de votre email Proconnect. 
-                                Veuillez contacter le support Tchap: support@tchap.numerique.gouv.fr. 
+                                Veuillez contacter le support Tchap: support@tchap.beta.gouv.fr. 
                                 email_tchap:{email:?}, proconnect_username:{localpart}"
                             ))
                             .with_language(&locale);
@@ -1364,7 +1364,7 @@ async fn validate_email_for_server(
                     "Votre adresse mail {email} est associée à un autre serveur."
                 ))
                 .with_details(
-                    "Veuillez-vous contacter le support de Tchap support@tchap.numerique.gouv.fr"
+                    "Veuillez-vous contacter le support de Tchap support@tchap.beta.gouv.fr"
                         .to_owned(),
                 )
                 .with_language(locale);

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -141,7 +141,7 @@ pub(crate) async fn get(
             .with_code("Compte desactivé")
             .with_description(format!(
                 r"Votre compte existe déjà mais il a été desactivé. 
-                Veuillez contacter le support Tchap: support@tchap.numerique.gouv.fr.
+                Veuillez contacter le support Tchap: support@tchap.beta.gouv.fr.
                 username:{}",
                 found_user.username
             ))

--- a/tchap/resources/templates/emails/recovery.html
+++ b/tchap/resources/templates/emails/recovery.html
@@ -8,7 +8,7 @@
 {% block primaryMessage %}
     <h2>Bonjour,</h2>
     <p>Une demande de réinitialisation de mot de passe a été reçue pour votre compte Tchap.</p>
-    <p>Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet email et contacter immédiatement le support <a href="mailto:support@tchap.numerique.gouv.fr">support@tchap.numerique.gouv.fr</a></p>
+    <p>Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet email et contacter immédiatement le support <a href="mailto:support@tchap.beta.gouv.fr">support@tchap.beta.gouv.fr</a></p>
     <p>Pour continuer la réinitialisation, veuillez cliquer sur le lien suivant (ou le copier-coller dans un navigateur).</p>
 {% endblock %}
 


### PR DESCRIPTION
Reverts tchapgouv/matrix-authentication-service#97

As the support@tchap.numerique.gouv.fr is not working.

In the futur, the email should be [support-tchap@numerique.gouv.fr](mailto:support-tchap@numerique.gouv.fr).
As this new redirection is not in place, we revert this change.