### PR TITLE
better handle of identity server error and wrong_server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6152,6 +6152,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 name = "tchap"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "mas-data-model",
  "mas-http",
  "mas-storage",

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -1433,11 +1433,11 @@ async fn validate_email_for_server(
     let email_result = check_email_allowed(email, server_name, tchap_config).await;
 
     match email_result {
-        EmailAllowedResult::Allowed => {
+        Ok(EmailAllowedResult::Allowed) => {
             // Email is allowed, continue
             Ok(None)
         }
-        EmailAllowedResult::WrongServer => {
+        Ok(EmailAllowedResult::WrongServer) => {
             // Email is mapped to a different server
             let ctx = ErrorContext::new()
                 .with_code("wrong_server")
@@ -1452,7 +1452,7 @@ async fn validate_email_for_server(
 
             Ok(Some(ctx))
         }
-        EmailAllowedResult::InvitationMissing => {
+        Ok(EmailAllowedResult::InvitationMissing) => {
             // Server requires an invitation that is not present
             let ctx = ErrorContext::new()
                 .with_code("invitation_missing")
@@ -1460,6 +1460,17 @@ async fn validate_email_for_server(
                 .with_details("Les partenaires externes peuvent accéder à Tchap uniquement avec une invitation d'un agent public.".to_owned())
                 .with_language(locale);
 
+            Ok(Some(ctx))
+        }
+        Err(_) => {
+            let ctx = ErrorContext::new()
+                .with_code("Identity Server Error")
+                .with_description("Impossible de contacter le serveur d'identité".to_owned())
+                .with_details(
+                    "Veuillez réessayer ou contacter le support de Tchap support@tchap.beta.gouv.fr"
+                        .to_owned(),
+                )
+                .with_language(locale);
             Ok(Some(ctx))
         }
     }
@@ -1516,7 +1527,7 @@ async fn check_email_allowed(
     email: &str,
     server_name: &str,
     tchap_config: &TchapConfig,
-) -> EmailAllowedResult {
+) -> Result<EmailAllowedResult, anyhow::Error> {
     tchap::is_email_allowed(email, server_name, tchap_config).await
 }
 ///mock function used when testing
@@ -1525,11 +1536,11 @@ async fn check_email_allowed(
     email: &str,
     _server_name: &str,
     _tchap_config: &TchapConfig,
-) -> EmailAllowedResult {
+) -> Result<EmailAllowedResult, anyhow::Error> {
     if email == "wrong_server@example.com" {
-        EmailAllowedResult::WrongServer
+        Ok(EmailAllowedResult::WrongServer)
     } else {
-        EmailAllowedResult::Allowed
+        Ok(EmailAllowedResult::Allowed)
     }
 }
 //:tchap:end

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -1437,12 +1437,12 @@ async fn validate_email_for_server(
             // Email is allowed, continue
             Ok(None)
         }
-        Ok(EmailAllowedResult::WrongServer) => {
+        Ok(EmailAllowedResult::WrongServer { server_name }) => {
             // Email is mapped to a different server
             let ctx = ErrorContext::new()
                 .with_code("wrong_server")
                 .with_description(format!(
-                    "Votre adresse mail {email} est associée à un autre serveur."
+                    "Votre adresse mail {email} est associée à un autre serveur: {server_name}."
                 ))
                 .with_details(
                     "Veuillez-vous contacter le support de Tchap support@tchap.beta.gouv.fr"
@@ -1538,7 +1538,9 @@ async fn check_email_allowed(
     _tchap_config: &TchapConfig,
 ) -> Result<EmailAllowedResult, anyhow::Error> {
     if email == "wrong_server@example.com" {
-        Ok(EmailAllowedResult::WrongServer)
+        Ok(EmailAllowedResult::WrongServer {
+            server_name: "test".to_owned(),
+        })
     } else {
         Ok(EmailAllowedResult::Allowed)
     }

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -246,13 +246,14 @@ pub(crate) async fn post(
                 Ok(EmailAllowedResult::Allowed) => {
                     // Email is allowed, continue
                 }
-                Ok(EmailAllowedResult::WrongServer) => {
+                Ok(EmailAllowedResult::WrongServer { server_name }) => {
                     state.add_error_on_field(
                         RegisterFormField::Email,
                         FieldError::Policy {
                             code: None,
-                            message: "Votre adresse mail est associée à un autre serveur."
-                                .to_owned(),
+                            message: format!(
+                                "Votre adresse mail est associée à un autre serveur {server_name}."
+                            ),
                         },
                     );
                 }

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -243,10 +243,10 @@ pub(crate) async fn post(
             let email_result = check_email_allowed(email, server_name, &tchap_config).await;
 
             match email_result {
-                EmailAllowedResult::Allowed => {
+                Ok(EmailAllowedResult::Allowed) => {
                     // Email is allowed, continue
                 }
-                EmailAllowedResult::WrongServer => {
+                Ok(EmailAllowedResult::WrongServer) => {
                     state.add_error_on_field(
                         RegisterFormField::Email,
                         FieldError::Policy {
@@ -256,13 +256,24 @@ pub(crate) async fn post(
                         },
                     );
                 }
-                EmailAllowedResult::InvitationMissing => {
+                Ok(EmailAllowedResult::InvitationMissing) => {
                     state.add_error_on_field(
                         RegisterFormField::Email,
                         FieldError::Policy {
                             code: None,
                             message: "Vous avez besoin d'une invitation pour accéder à Tchap"
                                 .to_owned(),
+                        },
+                    );
+                }
+                Err(_) => {
+                    state.add_error_on_field(
+                        RegisterFormField::Email,
+                        FieldError::Policy {
+                            code: None,
+                            message:
+                                "Impossible de contacter le serveur d'identité, veuillez réessayer ou contacter support@tchap.beta.gouv.fr"
+                                    .to_owned(),
                         },
                     );
                 }
@@ -538,7 +549,7 @@ async fn check_email_allowed(
     email: &str,
     server_name: &str,
     tchap_config: &TchapConfig,
-) -> EmailAllowedResult {
+) -> Result<EmailAllowedResult, anyhow::Error> {
     tchap::is_email_allowed(email, server_name, tchap_config).await
 }
 
@@ -547,8 +558,8 @@ async fn check_email_allowed(
     _email: &str,
     _server_name: &str,
     _tchap_config: &TchapConfig,
-) -> EmailAllowedResult {
-    EmailAllowedResult::Allowed
+) -> Result<EmailAllowedResult, anyhow::Error> {
+    Ok(EmailAllowedResult::Allowed)
 }
 //:tchap:end
 

--- a/crates/tchap/Cargo.toml
+++ b/crates/tchap/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 
 [dependencies]
+anyhow.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -166,7 +166,7 @@ pub enum EmailAllowedResult {
     /// Email is allowed on this server
     Allowed,
     /// Email is mapped to a different server
-    WrongServer,
+    WrongServer { server_name: String },
     /// Server requires an invitation that is not present
     InvitationMissing,
 }
@@ -194,12 +194,21 @@ pub async fn is_email_allowed(
     // Query the identity server
     match identity_client::query_identity_server(email, tchap_config).await {
         Ok(json) => {
-            let hs = json.get("hs");
+            let hs = json.get("hs").and_then(|v| v.as_str());
+
+            if hs.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Identity server answered with empty homeserver for email {}",
+                    email
+                ));
+            }
 
             // Check if "hs" is in the response or if hs different from server_name
-            if hs.is_none() || hs.unwrap() != server_name {
+            if hs.unwrap() != server_name {
                 // Email is mapped to a different server or no server at all
-                return Ok(EmailAllowedResult::WrongServer);
+                return Ok(EmailAllowedResult::WrongServer {
+                    server_name: hs.unwrap().to_string(),
+                });
             }
 
             info!(
@@ -501,7 +510,12 @@ mod tests {
 
         let result = is_email_allowed(email, server_name, &config).await;
 
-        assert_eq!(result.unwrap(), EmailAllowedResult::WrongServer);
+        assert_eq!(
+            result.unwrap(),
+            EmailAllowedResult::WrongServer {
+                server_name: "homeserver2".to_string()
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/tchap/src/lib.rs
+++ b/crates/tchap/src/lib.rs
@@ -28,7 +28,7 @@
 extern crate tracing;
 use mas_data_model::TchapConfig;
 use mas_storage::BoxRepository;
-use tracing::info;
+use tracing::{info, warn};
 
 mod identity_client;
 mod test_utils;
@@ -184,14 +184,13 @@ pub enum EmailAllowedResult {
 ///
 /// # Returns
 ///
-/// An `EmailAllowedResult` indicating whether the email is allowed and if not,
-/// why
-#[must_use]
+/// A `Result` containing `EmailAllowedResult` indicating whether the email is
+/// allowed, or an error if the HTTP request to the identity server failed
 pub async fn is_email_allowed(
     email: &str,
     server_name: &str,
     tchap_config: &TchapConfig,
-) -> EmailAllowedResult {
+) -> Result<EmailAllowedResult, anyhow::Error> {
     // Query the identity server
     match identity_client::query_identity_server(email, tchap_config).await {
         Ok(json) => {
@@ -200,10 +199,14 @@ pub async fn is_email_allowed(
             // Check if "hs" is in the response or if hs different from server_name
             if hs.is_none() || hs.unwrap() != server_name {
                 // Email is mapped to a different server or no server at all
-                return EmailAllowedResult::WrongServer;
+                return Ok(EmailAllowedResult::WrongServer);
             }
 
-            info!("hs: {} ", hs.unwrap());
+            info!(
+                ":tchap: - identity server - email {} is mapped to hs: {} ",
+                email,
+                hs.unwrap()
+            );
 
             // Check if requires_invite is true and invited is false
             let requires_invite = json
@@ -216,20 +219,23 @@ pub async fn is_email_allowed(
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
-            info!("requires_invite: {} invited: {}", requires_invite, invited);
+            info!(
+                ":tchap: - identity server - requires_invite {} invited: {}",
+                requires_invite, invited
+            );
 
             if requires_invite && !invited {
                 // Requires an invite but hasn't been invited
-                return EmailAllowedResult::InvitationMissing;
+                return Ok(EmailAllowedResult::InvitationMissing);
             }
 
             // All checks passed
-            EmailAllowedResult::Allowed
+            Ok(EmailAllowedResult::Allowed)
         }
         Err(err) => {
-            // Log the error and return WrongServer as a default error
-            eprintln!("HTTP request failed: {}", err);
-            EmailAllowedResult::WrongServer
+            // Log the error and return an error result
+            warn!(":tchap: - identity server - HTTP request failed: {}", err);
+            Err(anyhow::anyhow!(err))
         }
     }
 }
@@ -423,7 +429,7 @@ mod tests {
 
         let result = is_email_allowed(email, server_name, &config).await;
 
-        assert_eq!(result, EmailAllowedResult::Allowed);
+        assert_eq!(result.unwrap(), EmailAllowedResult::Allowed);
     }
 
     #[tokio::test]
@@ -459,7 +465,7 @@ mod tests {
 
         let result = is_email_allowed(email, server_name, &config).await;
 
-        assert_eq!(result, EmailAllowedResult::InvitationMissing);
+        assert_eq!(result.unwrap(), EmailAllowedResult::InvitationMissing);
     }
 
     #[tokio::test]
@@ -495,7 +501,7 @@ mod tests {
 
         let result = is_email_allowed(email, server_name, &config).await;
 
-        assert_eq!(result, EmailAllowedResult::WrongServer);
+        assert_eq!(result.unwrap(), EmailAllowedResult::WrongServer);
     }
 
     #[tokio::test]
@@ -531,6 +537,6 @@ mod tests {
 
         let result = is_email_allowed(email, server_name, &config).await;
 
-        assert_eq!(result, EmailAllowedResult::Allowed);
+        assert_eq!(result.unwrap(), EmailAllowedResult::Allowed);
     }
 }


### PR DESCRIPTION
- return server error instead of returning wrong_server when identity server is not reachable
- return name of wrong server 





<img width="300" alt="image" src="https://github.com/user-attachments/assets/b5c4ca4e-c09f-4897-8c20-7e13280d458d" />


- [x] E2E tests locally
