### PR TITLE
remove not maintained translations, leave only english and french

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,9 +150,10 @@ FROM --platform=${BUILDPLATFORM} scratch AS share
 COPY --from=frontend /share /share
 COPY --from=policy /app/policies/policy.wasm /share/policy.wasm
 COPY ./templates/ /share/templates
-COPY ./translations/ /share/translations
+
 
 #:tchap:
+#COPY ./translations/ /share/translations we do not want all translations, only french and english
 COPY ./tchap/resources/templates/ /share/templates/
 COPY ./tchap/resources/translations/ /share/translations/
 #:tchap:

--- a/tchap/resources/translations/en.json
+++ b/tchap/resources/translations/en.json
@@ -189,7 +189,7 @@
       }
     },
     "consent": {
-      "client_wants_access": "",
+      "client_wants_access": "You will find this new device in your list of Tchap devices.",
       "@client_wants_access": {
         "context": "pages/consent.html:41:11-122, pages/sso.html:37:11-72, sso.html:36:11-122"
       },


### PR DESCRIPTION
With not maintinaned translations we might come up with errors when an argument is missing: 

Fixes : https://github.com/tchapgouv/matrix-authentication-service/issues/130

 Unknown named argument 